### PR TITLE
feat: migrate schema on updates

### DIFF
--- a/dagster/src/assets/migrations/assets.py
+++ b/dagster/src/assets/migrations/assets.py
@@ -8,7 +8,7 @@ from src.utils.sentry import capture_op_exceptions
 
 from dagster import OpExecutionContext, asset
 
-from .core import save_schema_delta_table, validate_raw_schema
+from .core import get_filepath, save_schema_delta_table, validate_raw_schema
 
 
 @asset
@@ -27,7 +27,7 @@ def migrate_schema(
     spark: PySparkResource,
 ) -> None:
     s: SparkSession = spark.spark_session
-    filepath = context.run_tags["dagster/run_key"]
+    filepath = get_filepath(context)
     pdf = adls_file_client.download_csv_as_pandas_dataframe(filepath)
 
     filename = os.path.splitext(filepath.split("/")[-1])[0]

--- a/dagster/src/assets/migrations/core.py
+++ b/dagster/src/assets/migrations/core.py
@@ -9,8 +9,12 @@ from src.utils.delta import run_query_with_error_handler
 from dagster import OpExecutionContext
 
 
+def get_filepath(context: OpExecutionContext) -> str:
+    return context.run_tags["dagster/run_key"].split(":")[0]
+
+
 def validate_raw_schema(context: OpExecutionContext, df: sql.DataFrame):
-    filepath = context.run_tags["dagster/run_key"]
+    filepath = get_filepath(context)
 
     df = df.withColumn(
         "dq_invalid_data_type",
@@ -29,7 +33,7 @@ def validate_raw_schema(context: OpExecutionContext, df: sql.DataFrame):
 
 
 def save_schema_delta_table(context: OpExecutionContext, df: sql.DataFrame):
-    filepath = context.run_tags["dagster/run_key"]
+    filepath = get_filepath(context)
     spark = df.sparkSession
 
     filename = os.path.splitext(filepath.split("/")[-1])[0]

--- a/dagster/src/sensors/migrations.py
+++ b/dagster/src/sensors/migrations.py
@@ -12,14 +12,13 @@ from src.utils.adls import ADLSFileClient
 def migrations__schema_sensor():
     adls = ADLSFileClient()
     paths = adls.list_paths(constants.raw_schema_folder)
-    run_requests = []
 
     for path in paths:
         if path.is_directory:
             continue
 
         filepath = path["name"]
-        run_requests.append({"run_key": filepath})
+        properties = adls.get_file_metadata(filepath=filepath)
+        last_modified = properties["last_modified"].strftime("%Y%m%d-%H%M%S")
 
-    for request in run_requests:
-        yield RunRequest(**request)
+        yield RunRequest(run_key=f"{filepath}:{last_modified}")


### PR DESCRIPTION
## What type of PR is this?
- `feat`: Commits that add a new feature
- `refactor`: Commits that rewrite/restructure your code, however does not change any
  behaviour

## Summary
One-liner
- Automatically update schema delta tables when schema raw files are updated

State of code before this PR
- A `migrations__schema_sensor` exists where it triggers the `migrate__schema` job when new filepaths are detected in the `raw_schema` folder in ADLS
    - The sensor is triggered based on new filepaths because the `run_key` is currently based on `filepath`
    - Dagster sensors rely on `run_key` to prevent rerunning jobs, in this case, prevents re-detecting filepaths it has already processed (see [Idempotence using run keys](https://docs.dagster.io/concepts/partitions-schedules-sensors/sensors#idempotence-using-run-keys))
- The `migrate__schema` job converts csv files from `raw_schema` folder in ADLS, to delta tables in `warehouse-local/schemas.db` folder in ADLS

Changes made in this PR
- Allow the sensor to trigger jobs based on file updates vs new filepaths
    - Append each file's `last_modified` datetime to the `run_key` so that the `migrate__schema` job will be triggered based on filepath + datetime
- Because the `run_key` was modified to include datetime, assets downstream referring to `run_key` as `filepath` needs to be updated
    - Created a `get_filepath()` function to reduce redundant string indexing code
- Refactored `yield RunRequest` to remove `run_requests = []` to reduce code


## How to test
- Check that the sensor and job runs on new file updates
    - Re-upload the same csv file (or updated csv file) in `raw_schema` in ADLS (screenshot 1)
    - Check in Dagster that the `migrations__schema_sensor` triggers the `migrate__schema` job because it detects the file update, and that the job succeeds (screenshot 2)
- Check that the delta tables in `warehouse-local/schemas.db` is updated with new log files and parquet files (screenshot 3)
- Check that the delta table values are sensible
    - Read the delta table with spark and convert to csv
    - Check that the row numbers and values are the same + the new column created (screenshot 4)

## Screenshot of tests
1. <img width="573" alt="image-1" src="https://github.com/unicef/giga-dagster/assets/50901624/57d0928a-b2bf-4b84-8644-860844e25952">
2. <img width="1100" alt="image-2" src="https://github.com/unicef/giga-dagster/assets/50901624/c8e1c09a-a1a8-4571-8280-79d20309fc79">
3. <img width="1045" alt="image-3" src="https://github.com/unicef/giga-dagster/assets/50901624/492993fb-71f2-49aa-9b94-8da9badeaadd">
4. <img width="847" alt="image-4" src="https://github.com/unicef/giga-dagster/assets/50901624/1916066b-b8eb-4ed8-93cf-02d6253b4e3a">

## Link to Asana
[[T-US21-03] Schema Versioning](https://app.asana.com/0/1206270489214055/1206501779235495/f)