### PR TITLE
feat: update existing schema on new schema updates

### DIFF
--- a/azure/templates/create-config.yaml
+++ b/azure/templates/create-config.yaml
@@ -70,7 +70,6 @@ jobs:
                     PROCO_DB_CONNECTION_STRING: "$(procoDbConnectionString)"
                     SPARK_DRIVER_CORES: "$(sparkDriverCores)"
                     SPARK_DRIVER_MEMORY_MB: "$(sparkDriverMemoryMB)"
-                    GITHUB_ACCESS_TOKEN: "$(githubAccessToken)"
 
             - task: Kubernetes@1
               displayName: Create authproxy secrets

--- a/azure/templates/variables.yaml
+++ b/azure/templates/variables.yaml
@@ -36,5 +36,4 @@ variables:
   ingressHost: $(INGRESS_HOST)
   sparkDriverCores: $(SPARK_DRIVER_CORES)
   sparkDriverMemoryMB: $(SPARK_DRIVER_MEMORY_MB)
-  githubAccessToken: $(GITHUB_ACCESS_TOKEN)
   system.debug: true


### PR DESCRIPTION
## What type of PR is this?
- `feat`: Commits that add a new feature

## Summary
One-liner
- Automatically update schema of existing data delta tables when new schema delta tables exist
- Related to https://github.com/unicef/giga-dagster/pull/122

State of code before this PR
- For any asset using the `ADLS_DELTA_IO_MANAGER`, e.g. `@asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)`, it’s `handle_output` function merges new data to existing delta tables
- The merge is executed through the `_upsert_data` method, where the schema for the new data is retrieved from the schema delta tables through the `get_schema_columns` function, then merged to the existing delta tables
- This means, if the schema delta tables is different from the schema of the existing delta tables, the merge will fail due to mismatch of schema
- The schema of the existing delta table will first need to be updated before merging of new data can happen

Changes made in this PR
- Before executing the merge in the `_upsert_data` method;
- Retrieve the schema of the schema delta tables `updated_columns` and the existing schema `existing_columns` as a list of columns through the `fieldNames()` method
- If both lists of columns are different, create an empty dataframe with the `updated_schema` using the `emptyRDD()` method;
- Then update the schema of the existing delta table `full_table_name` with schema evolution ([reference](https://delta.io/blog/2023-02-08-delta-lake-schema-evolution/)), by adding the `.option("mergeSchema", "true")`


## How to test
- Migrate an updated schema csv to schema delta table
    - Re-upload `school-master.csv` to ADLS `raw-tiff/schema` but add a new row to the file e.g. `00000000-0000-0000-0000-000000000003,newcolumn,string,true,,,,,,,,` (screenshot 1 & 2)
    - Run the `migrations__schema_sensor` to process the updated schema, you should see the updated schema delta table in `warehouse-local-tiff/schemas.db/school_master` (screenshot 3)
- Check that the schema of the existing delta table is updated when new schema delta tables exist
    - Upload “new data” to ADLS `updated_master_schema-tiff/master_updates/AFG_school_geolocation_coverage_master1.csv` (screenshot 4)
        - This is an exact copy of the first 3 rows of `updated_master_schema-tiff/master/AFG_school_geolocation_coverage_master.csv` except with the `school_name` values replaced with `<any text>` (screenshot 5)
    - Run the `school_master__gold_csv_to_deltatable_sensor` from the adhoc pipeline, you should see the updated existing delta table in `warehouse-local-tiff/school_master.db/afg` (screenshot 6)
    - Read the `afg` delta table as csv, with the `newcolumn` and the `<any text>` populated (screenshot 7)

## Screenshot of tests
1. <img width="1224" alt="screenshot 1" src="https://github.com/unicef/giga-dagster/assets/50901624/37f6813b-d137-4cc5-b364-4dc9092c1901">
2. <img width="1245" alt="screenshot 2" src="https://github.com/unicef/giga-dagster/assets/50901624/b866a7d8-99e4-4e92-9789-e0acfa3ffa17">
3. <img width="1221" alt="screenshot 3" src="https://github.com/unicef/giga-dagster/assets/50901624/e18b1301-efad-4938-b2aa-e34308ad5fdc">
4. <img width="1217" alt="screenshot 4" src="https://github.com/unicef/giga-dagster/assets/50901624/9ddf2e7f-bebf-496a-9879-63ba05173513">
5. <img width="1234" alt="screenshot 5" src="https://github.com/unicef/giga-dagster/assets/50901624/ae95d307-4fa1-40bc-80a8-8de172ccdbb7">
6. <img width="1217" alt="screenshot 6" src="https://github.com/unicef/giga-dagster/assets/50901624/d35f1cef-08f9-4672-9696-1a1a1e291e01">
7. <img width="1264" alt="screenshot 7" src="https://github.com/unicef/giga-dagster/assets/50901624/a01b7fa3-b68a-4f48-a246-40351ae55580">

## Link to Asana
[[T-US21-03] Schema Versioning](https://app.asana.com/0/1206270489214055/1206501779235495/f)