### PR TITLE
feat: save dq results as delta table

### DIFF
--- a/dagster/src/assets/school_coverage/assets.py
+++ b/dagster/src/assets/school_coverage/assets.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from io import BytesIO
 
 import pandas as pd
@@ -36,10 +37,15 @@ from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
 from src.utils.db import get_db_context
+from src.utils.delta import create_delta_table, create_schema
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
 from src.utils.pandas import pandas_loader
-from src.utils.schema import get_schema_columns, get_schema_columns_datahub
+from src.utils.schema import (
+    construct_full_table_name,
+    get_schema_columns,
+    get_schema_columns_datahub,
+)
 from src.utils.send_email_dq_report import send_email_dq_report_with_config
 
 from dagster import OpExecutionContext, Output, asset
@@ -87,6 +93,10 @@ def coverage_data_quality_results(
         pdf = pandas_loader(buffer, config.filepath)
 
     source = config.filename_components.source
+    schema_name = config.metastore_schema
+    id = config.filename_components.id
+    country_code = config.country_code
+    current_timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
 
     df_raw = s.createDataFrame(pdf)
     df, column_mapping = column_mapping_rename(
@@ -104,16 +114,24 @@ def coverage_data_quality_results(
 
     config.metadata.update({"column_mapping": column_mapping})
 
-    filepath_id = config.filepath.split("/")[-1].split("_")[0]
-    filepath_timestamp = config.filepath.split(".")[0].split("_")[-1].replace("-", "_")
+    dq_results_schema_name = f"{schema_name}_{source}_dq_results"
+    table_name = f"{id}_{country_code}_{current_timestamp}"
+    schema_columns = dq_results.schema.fields
+    dq_results_table_name = construct_full_table_name(
+        dq_results_schema_name,
+        table_name,
+    )
 
-    schema_name = f"{config.metastore_schema}_{source}_dq_results"
-    table_name = f"{filepath_id}_{config.country_code}_{filepath_timestamp}"
-    full_table_name = f"{schema_name}.{table_name}"
-
-    s: SparkSession = spark.spark_session
-    s.sql(f"CREATE SCHEMA IF NOT EXISTS `{schema_name}`")
-    dq_results.write.format("delta").mode("overwrite").saveAsTable(full_table_name)
+    create_schema(s, dq_results_schema_name)
+    create_delta_table(
+        s,
+        dq_results_schema_name,
+        table_name,
+        schema_columns,
+        context,
+        if_not_exists=True,
+    )
+    dq_results.write.format("delta").mode("append").saveAsTable(dq_results_table_name)
 
     datahub_emit_metadata_with_exception_catcher(
         context=context,

--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from io import BytesIO
 
 import pandas as pd
@@ -30,10 +31,12 @@ from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
 from src.utils.db import get_db_context
+from src.utils.delta import create_delta_table, create_schema
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
 from src.utils.pandas import pandas_loader
 from src.utils.schema import (
+    construct_full_table_name,
     get_schema_columns,
     get_schema_columns_datahub,
 )
@@ -116,6 +119,8 @@ def geolocation_data_quality_results(
     geolocation_bronze: sql.DataFrame,
     spark: PySparkResource,
 ) -> Output[pd.DataFrame]:
+    s: SparkSession = spark.spark_session
+
     datahub_emit_metadata_with_exception_catcher(
         context=context,
         config=config,
@@ -123,6 +128,10 @@ def geolocation_data_quality_results(
     )
 
     country_code = config.country_code
+    schema_name = config.metastore_schema
+    id = config.filename_components.id
+    current_timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+
     dq_results = row_level_checks(
         geolocation_bronze,
         "geolocation",
@@ -130,16 +139,24 @@ def geolocation_data_quality_results(
         context,
     )
 
-    filepath_id = config.filepath.split("/")[-1].split("_")[0]
-    filepath_timestamp = config.filepath.split(".")[0].split("_")[-1].replace("-", "_")
+    dq_results_schema_name = f"{schema_name}_dq_results"
+    table_name = f"{id}_{country_code}_{current_timestamp}"
+    schema_columns = dq_results.schema.fields
+    dq_results_table_name = construct_full_table_name(
+        dq_results_schema_name,
+        table_name,
+    )
 
-    schema_name = f"{config.metastore_schema}_dq_results"
-    table_name = f"{filepath_id}_{country_code}_{filepath_timestamp}"
-    full_table_name = f"{schema_name}.{table_name}"
-
-    s: SparkSession = spark.spark_session
-    s.sql(f"CREATE SCHEMA IF NOT EXISTS `{schema_name}`")
-    dq_results.write.format("delta").mode("overwrite").saveAsTable(full_table_name)
+    create_schema(s, dq_results_schema_name)
+    create_delta_table(
+        s,
+        dq_results_schema_name,
+        table_name,
+        schema_columns,
+        context,
+        if_not_exists=True,
+    )
+    dq_results.write.format("delta").mode("append").saveAsTable(dq_results_table_name)
 
     dq_pandas = dq_results.toPandas()
     return Output(


### PR DESCRIPTION
## What type of PR is this?
- `feat`: Commits that add a new feature

## Summary
One-liner
- Save `dq_results` dataframe output from `data_quality_results` asset as a delta table, so that the data can be exposed to Superset

State of code before this PR
- The `data_quality_results` asset uses the `ADLS_PANDAS_IO_MANAGER` which saves the asset's dataframe output as a CSV file in ADLS
- Creating another downstream asset that makes use of the `ADLS_DELTA_IO_MANAGER` is not advisable since the IO manager contains extra logic (related to merging) that won't be used
- Can create a task that saves the `dq_results` dataframe output as a delta table within the `data_quality_results` asset

Changes made in this PR
- Set the `table_name` as `{id}_{country}_{timestamp}` by getting the necessary fields in the `filepath`
- Set the `schema_name` as `{metastore_schema}`, + `{source}` for coverage since coverage has two types of data uploads from different source `fb` and `itu`, both with different schemas
- Schema needs to be created before the table can be saved to the schema in `full_table_name`
- Save the table as delta table with `overwrite` mode
    - This asset is only expected to run once per file, so the `overwrite` mode will make the pipeline robust to re-runs
- The table will be saved in `{SPARK_WAREHOUSE_PATH}/{schema_name}.db` in ADLS

## How to test
- Upload a file to `raw-tiff/uploads/school-coverage` to trigger the pipeline run (screenshot 1)
    - Make sure the schema is correct in https://io-dataingestion-dev.unitst.org/ 
    - Comment out `db` related code in `assets.py`
- Run the `school_master_coverage__raw_file_uploads_sensor` and check if a new delta table is created in `warehouse-local-tiff/school_coverage_fb.db` (screenshot 2)

## Screenshot of tests
1. <img width="1413" alt="Screenshot 2024-05-07 at 2 05 26 PM" src="https://github.com/unicef/giga-dagster/assets/50901624/e2363086-9a7a-484d-9b9c-13cd413855a7">
2. <img width="1411" alt="Screenshot 2024-05-07 at 2 06 06 PM" src="https://github.com/unicef/giga-dagster/assets/50901624/f16f3c52-03e6-4fd7-b068-61a713a2621c">

## Link to Asana
[[US81] DQ checks on Superset](https://app.asana.com/0/1206270489214055/1207121462958102)