### PR TITLE
Fix/schema values missing

### DIFF
--- a/dagster/src/internal/common_assets/staging.py
+++ b/dagster/src/internal/common_assets/staging.py
@@ -102,8 +102,11 @@ class StagingStep:
                 staging = self.upsert_staging(staging)
             else:
                 self.create_empty_staging_table()
-                staging.write.format("delta").mode("append").saveAsTable(
-                    self.staging_table_name
+                (
+                    staging.write.option("mergeSchema", "true")
+                    .format("delta")
+                    .mode("append")
+                    .saveAsTable(self.staging_table_name)
                 )
 
             self.context.log.info(f"Full {staging.count()=}")


### PR DESCRIPTION
## What type of PR is this?
- `fix`: Commits that fix a bug

## Summary
One-liner
- Two bugs
    - New schema fields are merged to existing delta tables, but the values of new schema fields only show as null
    - Schema was not being updated for the condition where silver table does not exist
- Related to https://github.com/unicef/giga-dagster/pull/167 

State of code before this PR
- To-do

Changes made in this PR
- First bug: Add `reload_schema()` function
- Second bug: Add `sync_schema()` and `reload_schema()` to the condition where silver table does not exist but staging table exists

## How to test
- Migrate schema
    - Re-upload to `raw-tiff/schema` for `school-geolocation.csv` and `school-master.csv`
        - Add `00000000-0000-0000-0000-000000000003,newgeo_column,string,true,,,,,,,,`
    - Turn on `migrations__schema_sensor`
    - Output in `warehouse-local-tiff/schemas.db` for `school_geolocation` and `school_master`
- Test geolocation pipeline
    - Upload to `raw-tiff/uploads/school-geolocation`
        - Rename timestamp to `xiky50901uul8fn0t3tzqhg4_KAZ_geolocation_20240509-000000.csv`
        - Copy first 3 rows and add `newgeo_column` and give the value `newgeo_string`
        - Temporarily comment out `db` related code in `school_geolocation/assets.py` and `staging.py`
    - Turn on `school_master_geolocation__raw_file_uploads_sensor`
    - Output in `warehouse-local-tiff/school_geolocation_staging.db/kaz`
- Test adhoc master pipeline
    - Upload base `KAZ` delta table to `updated_master_schema-tiff/master`
    - Turn on and off `school_master__gold_csv_to_deltatable_sensor`
    - Output in `warehouse-local-tiff/school_master.db/kaz`
    - Upload to `updated_master_schema-tiff/master_updates`
        - Copy first 3 rows and add `newgeo_column` and give the value `newgeo_string`
    - Turn on `school_master__gold_csv_to_deltatable_sensor`
    - Output in `warehouse-local-tiff/school_master.db/kaz`

## Screenshot of tests
Similar screenshots to https://github.com/unicef/giga-dagster/pull/167 

## Link to Asana
[[T-US21-03] Schema Versioning](https://app.asana.com/0/1206270489214055/1206501779235495/f)