### PR TITLE
fix: cast columns to long then string

### DIFF
--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -10,7 +10,7 @@ from pyspark.sql import (
     SparkSession,
     functions as f,
 )
-from pyspark.sql.types import StructType
+from pyspark.sql.types import LongType, StringType, StructType
 from sqlalchemy import select
 from src.constants import DataTier
 from src.data_quality_checks.utils import (
@@ -112,10 +112,18 @@ def geolocation_bronze(
         silver = s.createDataFrame(s.sparkContext.emptyRDD(), schema=schema)
 
     casted_silver = silver.withColumn(
-        "school_id_govt", f.col("school_id_govt").cast("long").cast("string")
+        "school_id_govt",
+        f.when(
+            f.col("school_id_govt").cast(LongType()).isNotNull(),
+            f.col("school_id_govt").cast(LongType()).cast(StringType()),
+        ).otherwise(f.col("school_id_govt").cast(StringType())),
     )
     casted_bronze = df.withColumn(
-        "school_id_govt", f.col("school_id_govt").cast("long").cast("string")
+        "school_id_govt",
+        f.when(
+            f.col("school_id_govt").cast(LongType()).isNotNull(),
+            f.col("school_id_govt").cast(LongType()).cast(StringType()),
+        ).otherwise(f.col("school_id_govt").cast(StringType())),
     )
 
     df = create_bronze_layer_columns(casted_bronze, casted_silver, country_code)
@@ -169,10 +177,18 @@ def geolocation_data_quality_results(
         silver = s.createDataFrame(s.sparkContext.emptyRDD(), schema=schema)
 
     casted_silver = silver.withColumn(
-        "school_id_govt", f.col("school_id_govt").cast("long").cast("string")
+        "school_id_govt",
+        f.when(
+            f.col("school_id_govt").cast(LongType()).isNotNull(),
+            f.col("school_id_govt").cast(LongType()).cast(StringType()),
+        ).otherwise(f.col("school_id_govt").cast(StringType())),
     )
     casted_bronze = geolocation_bronze.withColumn(
-        "school_id_govt", f.col("school_id_govt").cast("long").cast("string")
+        "school_id_govt",
+        f.when(
+            f.col("school_id_govt").cast(LongType()).isNotNull(),
+            f.col("school_id_govt").cast(LongType()).cast(StringType()),
+        ).otherwise(f.col("school_id_govt").cast(StringType())),
     )
 
     dq_results = row_level_checks(


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary


Casts `school_id_govt` colums to long and then to string. `school_id_govt` contains numeric values that can potentially have more than 10 digits. PySpark converts these columns into `double` or `float` (with decimals) which causes problems with the `ON school_id_govt` clause during joins.

The fix casts the decimat values into `long` which has a higher limit compared to `int` in order to remove the decimal, and then recats the value to a `string` for future parsing

## How to test

1. Go through upload flow with a csv that contains new or existing values. Choose any of create/update flow
2. After the runs complete, assert that `is_not_update` or `is_not_create` partially passes/fails depending on your test data
3. Download the csv and assert that the error checks are shown



## Link to Jira/Asana/Airtable task (if applicable)

https://app.asana.com/0/1207713905378556/1208069247817249

## Wireframe screenshot/screencap (if applicable)

![image](https://github.com/user-attachments/assets/80a6252a-d8ae-400d-adbf-025d3b1e28ea)



