### PR TITLE
feat: [R-38] send dq reports to admins

### DIFF
--- a/dagster/src/utils/send_email_dq_report.py
+++ b/dagster/src/utils/send_email_dq_report.py
@@ -32,7 +32,7 @@ async def send_email_dq_report(
     }
 
     admins = GroupsApi.list_role_members("Admin")
-    recipients = [uploader_email, *admins]
+    recipients = list({uploader_email, *admins})
 
     get_context_with_fallback_logger(context).info("SENDING DQ REPORT VIA EMAIL...")
     get_context_with_fallback_logger(context).info(metadata)


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary

Sends DQ report results to admins aside from the original uploader

## How to test

 Must be merged with https://github.com/unicef/giga-data-ingestion/pull/140


1. Have a non admin and an admin account on hand
2. Go through the upload flow
3. Assert that both you (the uploader) and an admin account receives the DQ report email

## Link to Jira/Asana/Airtable task (if applicable)

https://app.asana.com/0/1207713905378556/1208165477249482
