### PR TITLE
fix: [W-09] Update column selection logic

### DIFF
--- a/dagster/src/data_quality_checks/utils.py
+++ b/dagster/src/data_quality_checks/utils.py
@@ -248,7 +248,7 @@ def dq_split_passed_rows(df: sql.DataFrame, dataset_type: str):
         columns = [
             col
             for col in df.columns
-            if not col.startswith("dq_") and col != "failure_reason"
+            if not col.startswith("dq_") or col != "failure_reason"
         ]
 
     df = df.filter(df.dq_has_critical_error == 0)


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug


## Summary

Fix for this [failing run](
https://io-dagster-dev.unitst.org/runs/d24563bb-fdc1-4804-987b-821b3a2d0381
).

column `failure_reason` was appearing at the `geolocation_staging` step. This PR updates a data-quality-check function to properly strip out `failure_reason` which should only appear in the human readable dq checks.


## Link to Jira/Asana/Airtable task (if applicable)

[_placeholder_
](https://docs.google.com/spreadsheets/d/10XGM96Vj3JGJoWOR4p4ET8-Z9nvFFCByDXWZV8C76zg/edit?gid=1993667304#gid=1993667304)
