### PR TITLE
fix: [W-11] update alter statements

### DIFF
--- a/dagster/src/internal/common_assets/staging.py
+++ b/dagster/src/internal/common_assets/staging.py
@@ -244,8 +244,9 @@ class StagingStep:
             )
 
         if has_nullability_changed:
-            alter_sql = f"{alter_sql} {', '.join(alter_stmts)};"
-            self.spark.sql(alter_sql).show()
+            alter_sql = [f"{alter_sql} {alter_stmt}" for alter_stmt in alter_stmts]
+            for stmnt in alter_sql:
+                self.spark.sql(stmnt).show()
 
         if has_schema_changed or has_nullability_changed:
             self.reload_schema()

--- a/dagster/src/internal/common_assets/staging.py
+++ b/dagster/src/internal/common_assets/staging.py
@@ -223,11 +223,9 @@ class StagingStep:
             ) is not None:
                 if match_.nullable != column.nullable:
                     if match_.nullable:
-                        alter_stmts.append(
-                            f'ALTER COLUMN "{column.name}" DROP NOT NULL'
-                        )
+                        alter_stmts.append(f"ALTER COLUMN {column.name} DROP NOT NULL")
                     else:
-                        alter_stmts.append(f'ALTER COLUMN "{column.name}" SET NOT NULL')
+                        alter_stmts.append(f"ALTER COLUMN {column.name} SET NOT NULL")
 
         has_nullability_changed = len(alter_stmts) > 0
         has_schema_changed = updated_columns != existing_columns


### PR DESCRIPTION
## What type of PR is this?
- `fix`: Commits that fix a bug

## Summary

- Removes uneeded double quotes in the  column names of SQL statements
- Places `ALTER TABLE` statements in a loop since multiple statements do not work in spark