### PR TITLE
fix [W-15]: add data type change handling to bulk updates

### DIFF
--- a/dagster/src/internal/common_assets/staging.py
+++ b/dagster/src/internal/common_assets/staging.py
@@ -96,7 +96,7 @@ class StagingStep:
                 # If silver table exists and no staging table exists, clone it to staging
                 self.create_staging_table_from_silver()
 
-            self.sync_schema()
+            self.sync_schema_staging()
 
             # If silver table exists and staging table exists, merge files for review to existing staging table
             if self.change_type != StagingChangeTypeEnum.DELETE:
@@ -111,7 +111,7 @@ class StagingStep:
                 staging = self.standard_transforms(upstream_df)
 
                 if self.staging_table_exists:
-                    self.sync_schema()
+                    self.sync_schema_staging()
                     staging = self.upsert_rows(staging)
                 else:
                     self.create_empty_staging_table()
@@ -203,7 +203,7 @@ class StagingStep:
             if_not_exists=True,
         )
 
-    def sync_schema(self):
+    def sync_schema_staging(self):
         """Update the schema of existing delta tables based on the reference schema delta tables."""
         self.context.log.info("Checking for schema update...")
         updated_schema = StructType(self.schema_columns)

--- a/dagster/src/resources/io_managers/adls_delta.py
+++ b/dagster/src/resources/io_managers/adls_delta.py
@@ -181,6 +181,10 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
             existing_columns = sorted(existing_df.schema.fieldNames())
             context.log.info(f"Existing columns {existing_columns}")
             context.log.info(f"Updated df {updated_columns}")
+
+            context.log.info(f"incoming schema {data.schema}")
+            context.log.info(f"existing schema {existing_df.schema}")
+
             if updated_columns != existing_columns:
                 context.log.info("Updating schema...")
 

--- a/dagster/src/resources/io_managers/adls_delta.py
+++ b/dagster/src/resources/io_managers/adls_delta.py
@@ -179,8 +179,6 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
 
             existing_df = DeltaTable.forName(spark, full_table_name).toDF()
             existing_columns = sorted(existing_df.schema.fieldNames())
-            context.log.info(f"Existing columns {existing_columns}")
-            context.log.info(f"Updated df {updated_columns}")
 
             context.log.info(f"incoming schema {data.schema}")
             context.log.info(f"existing schema {existing_df.schema}")

--- a/dagster/src/resources/io_managers/adls_delta.py
+++ b/dagster/src/resources/io_managers/adls_delta.py
@@ -41,7 +41,7 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
             config.metastore_schema, config.tier
         )
         full_table_name = f"{schema_tier_name}.{table_name}"
-        context.log.info("Full table name", full_table_name)
+        context.log.info(f"Full table name: {full_table_name}")
 
         self._create_schema_if_not_exists(schema_tier_name)
         self._create_table_if_not_exists(context, output, schema_tier_name, table_name)
@@ -179,8 +179,11 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
 
             existing_df = DeltaTable.forName(spark, full_table_name).toDF()
             existing_columns = sorted(existing_df.schema.fieldNames())
-
+            context.log.info(f"Existing columns {existing_columns}")
+            context.log.info(f"Updated df {updated_columns}")
             if updated_columns != existing_columns:
+                context.log.info("Updating schema...")
+
                 empty_data = spark.sparkContext.emptyRDD()
                 updated_schema_df = spark.createDataFrame(
                     data=empty_data, schema=updated_schema

--- a/dagster/src/resources/io_managers/adls_delta.py
+++ b/dagster/src/resources/io_managers/adls_delta.py
@@ -29,6 +29,7 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
     pyspark: PySparkResource
 
     def handle_output(self, context: OutputContext, output: sql.DataFrame | None):
+        context.log.info("Handling DeltaIOManager output...")
         if output is None:
             return
         if output.isEmpty():
@@ -40,6 +41,8 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
             config.metastore_schema, config.tier
         )
         full_table_name = f"{schema_tier_name}.{table_name}"
+        context.log.info("Full table name", full_table_name)
+
         self._create_schema_if_not_exists(schema_tier_name)
         self._create_table_if_not_exists(context, output, schema_tier_name, table_name)
         self._upsert_data(output, config.metastore_schema, full_table_name, context)
@@ -49,6 +52,8 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
         )
 
     def load_input(self, context: InputContext) -> sql.DataFrame:
+        context.log.info("Handling DeltaIOManager input...")
+
         table_name, _, _ = self._get_table_path(context)
         spark = self._get_spark_session()
         config = FileConfig(
@@ -57,7 +62,11 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
         schema_name = config.metastore_schema
 
         schema_tier_name = construct_schema_name_for_tier(schema_name, config.tier)
+        context.log.info(f"Schema_tier_name: {schema_tier_name}")
+
         full_table_name = construct_full_table_name(schema_tier_name, table_name)
+        context.log.info(f"full_table_name: {full_table_name}")
+        context.log.info(full_table_name)
 
         dt = DeltaTable.forName(spark, full_table_name)
 

--- a/dagster/src/utils/delta.py
+++ b/dagster/src/utils/delta.py
@@ -228,18 +228,24 @@ def check_table_exists(
     )
 
 
-def count_changed_datatypes(
-    existing_schema: StructType, updated_schema: StructType
+def get_changed_datatypes(
+    context: OpExecutionContext, existing_schema: StructType, updated_schema: StructType
 ) -> dict[str, DataType]:
+    original_datatypes = {}
     changed_datatypes = {}
+    context.log.info(f"Existing schema {existing_schema}")
+    context.log.info(f"Updated schema {updated_schema}")
 
     for column in existing_schema:
         if (
             match_ := next((c for c in updated_schema if c.name == column.name), None)
         ) is not None:
             if match_.dataType != column.dataType:
-                changed_datatypes[match_.name] = column.dataType
+                changed_datatypes[match_.name] = match_.dataType
+                original_datatypes[match_.name] = column.dataType
 
+    context.log.info(f"Original datatypes: {original_datatypes}")
+    context.log.info(f"Changed datatypes: {changed_datatypes}")
     return changed_datatypes
 
 

--- a/dagster/src/utils/delta.py
+++ b/dagster/src/utils/delta.py
@@ -287,25 +287,6 @@ def sync_schema(
     )
     has_datatype_changed = len(changed_datatypes) > 0
 
-    if has_schema_changed:
-        context.log.info("Adding schema columns...")
-        updated_schema = spark.createDataFrame([], schema=updated_schema)
-        (
-            updated_schema.write.option("mergeSchema", "true")
-            .format("delta")
-            .mode("append")
-            .saveAsTable(table_name)
-        )
-
-    if has_nullability_changed:
-        context.log.info(
-            "Modifying column nullabilities with the SQL statements{alter_sql}..."
-        )
-
-        alter_sql = [f"{alter_sql} {alter_stmt}" for alter_stmt in alter_stmts]
-        for stmnt in alter_sql:
-            spark.sql(stmnt).show()
-
     if has_datatype_changed:
         context.log.info("Updating datatype...")
         existing_dataframe = spark.table(table_name)
@@ -322,3 +303,24 @@ def sync_schema(
             .mode("overwrite")
             .saveAsTable(table_name)
         )
+
+    if has_schema_changed:
+        context.log.info("Adding schema columns...")
+        empty_dataframe_with_updated_schema = spark.createDataFrame(
+            [], schema=updated_schema
+        )
+        (
+            empty_dataframe_with_updated_schema.write.option("mergeSchema", "true")
+            .format("delta")
+            .mode("append")
+            .saveAsTable(table_name)
+        )
+
+    if has_nullability_changed:
+        context.log.info(
+            "Modifying column nullabilities with the SQL statements{alter_sql}..."
+        )
+
+        alter_sql = [f"{alter_sql} {alter_stmt}" for alter_stmt in alter_stmts]
+        for stmnt in alter_sql:
+            spark.sql(stmnt).show()

--- a/dagster/src/utils/delta.py
+++ b/dagster/src/utils/delta.py
@@ -241,3 +241,19 @@ def count_changed_datatypes(
                 changed_datatypes[match_.name] = column.dataType
 
     return changed_datatypes
+
+
+def build_nullability_queries(
+    existing_schema: StructType, updated_schema: StructType
+) -> list[str]:
+    alter_stmts = []
+    for column in existing_schema:
+        if (
+            match_ := next((c for c in updated_schema if c.name == column.name), None)
+        ) is not None:
+            if match_.nullable != column.nullable:
+                if match_.nullable:
+                    alter_stmts.append(f"ALTER COLUMN {column.name} DROP NOT NULL")
+                else:
+                    alter_stmts.append(f"ALTER COLUMN {column.name} SET NOT NULL")
+    return alter_stmts

--- a/dagster/src/utils/spark.py
+++ b/dagster/src/utils/spark.py
@@ -218,9 +218,19 @@ def transform_types(
     schema_name: str,
     context: OpExecutionContext | OutputContext = None,
 ) -> sql.DataFrame:
+    """
+    Retuns a dataframe with columns casted to use types in provided schema.
+    """
+
     logger = get_context_with_fallback_logger(context)
 
     columns = get_schema_columns(df.sparkSession, schema_name)
+    context.log.info(f"Schema name: {schema_name}")
+    context.log.info(f"Schema columns: {columns}")
+
+    master_columns = get_schema_columns(df.sparkSession, "school_master")
+    context.log.info(f"Master columns: {master_columns}")
+
     if schema_name == "qos":
         columns = [c for c in columns if c.name in df.columns]
 

--- a/dagster/src/utils/spark.py
+++ b/dagster/src/utils/spark.py
@@ -229,7 +229,10 @@ def transform_types(
     context.log.info(f"Schema columns: {columns}")
 
     master_columns = get_schema_columns(df.sparkSession, "school_master")
+    reference_columns = get_schema_columns(df.sparkSession, "school_reference")
+
     context.log.info(f"Master columns: {master_columns}")
+    context.log.info(f"Reference columns columns: {reference_columns}")
 
     if schema_name == "qos":
         columns = [c for c in columns if c.name in df.columns]


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature
- `fix`: Commits that fix a bug
- `refactor`: Commits that rewrite/restructure your code, however does not change any
  behaviour


## Summary

- Adds datatype change handling to reference bulk updates (also known as `csv to gold`)
- Also adds extra loggers.

## How to test

1. Update the datatype of a column in `school-reference`
2. Turn on the `migrations__schema_sensor` and wait for the spawned dag to complete
3. Update a datatype in the reference file for your preferred country in `updated_master_schema/reference/`
4. Turn on the `school_master__gold_csv_to_deltatable_sensor`
5. Triger the bulk update by uploading a new file in the `master_updates` bucketfe.g. for brazil (`updated_master_schema/master_updates/BRA/). You may get the most recent file in that bucket and rep
6. Assert that the run completes