### PR TITLE
fix: merge types error when converting from pandas to spark df

### DIFF
--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -95,7 +95,7 @@ def geolocation_bronze(
 
     with BytesIO(geolocation_raw) as buffer:
         buffer.seek(0)
-        pdf = pandas_loader(buffer, config.filepath)
+        pdf = pandas_loader(buffer, config.filepath).map(str)
 
     df = s.createDataFrame(pdf)
     df, column_mapping = column_mapping_rename(df, file_upload.column_to_schema_mapping)


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Geolocation files being uploaded to Giga Sync can have columns where several numeric datatypes are present (e.g. having both a double and a long). This results in Spark raising a merge type error as it does not automatically merge numeric datatypes across different precisions.

By converting all columns in the Pandas DataFrame to object/string type, Spark will be able to read these columns successfully.

## How to test

1. Perform a Create upload flow via Giga Sync