### PR TITLE
feat: attach sentry to all assets

### DIFF
--- a/dagster/src/assets/adhoc/generate_silver_from_gold.py
+++ b/dagster/src/assets/adhoc/generate_silver_from_gold.py
@@ -11,12 +11,14 @@ from src.utils.delta import check_table_exists, execute_query_with_error_handler
 from src.utils.metadata import get_table_preview
 from src.utils.op_config import DatasetConfig
 from src.utils.schema import get_schema_columns
+from src.utils.sentry import capture_op_exceptions
 from src.utils.spark import compute_row_hash, transform_types
 
 from dagster import OpExecutionContext, Output, asset
 
 
 @asset
+@capture_op_exceptions
 def adhoc__generate_silver_geolocation_from_gold(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -102,6 +104,7 @@ def adhoc__generate_silver_geolocation_from_gold(
 
 
 @asset
+@capture_op_exceptions
 def adhoc__generate_silver_coverage_from_gold(
     context: OpExecutionContext,
     spark: PySparkResource,

--- a/dagster/src/assets/adhoc/master_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/master_csv_to_gold.py
@@ -46,6 +46,7 @@ from src.utils.schema import (
     get_schema_columns,
     get_schema_columns_datahub,
 )
+from src.utils.sentry import capture_op_exceptions
 from src.utils.spark import compute_row_hash, transform_types
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -53,6 +54,7 @@ from dagster import OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__load_master_csv(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -69,6 +71,7 @@ def adhoc__load_master_csv(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__load_reference_csv(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -92,6 +95,7 @@ def adhoc__load_reference_csv(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__master_data_transforms(
     context: OpExecutionContext,
     adhoc__load_master_csv: bytes,
@@ -153,6 +157,7 @@ def adhoc__master_data_transforms(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__df_duplicates(
     context: OpExecutionContext,
     adhoc__master_data_transforms: sql.DataFrame,
@@ -175,6 +180,7 @@ def adhoc__df_duplicates(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__master_data_quality_checks(
     context: OpExecutionContext,
     adhoc__master_data_transforms: sql.DataFrame,
@@ -215,6 +221,7 @@ def adhoc__master_data_quality_checks(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__reference_data_quality_checks(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -272,6 +279,7 @@ def adhoc__reference_data_quality_checks(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__master_dq_checks_passed(
     context: OpExecutionContext,
     adhoc__master_data_quality_checks: sql.DataFrame,
@@ -304,6 +312,7 @@ def adhoc__master_dq_checks_passed(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__reference_dq_checks_passed(
     _: OpExecutionContext,
     config: FileConfig,
@@ -339,6 +348,7 @@ def adhoc__reference_dq_checks_passed(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__master_dq_checks_failed(
     context: OpExecutionContext,
     adhoc__master_data_quality_checks: sql.DataFrame,
@@ -361,6 +371,7 @@ def adhoc__master_dq_checks_failed(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__reference_dq_checks_failed(
     _: OpExecutionContext,
     config: FileConfig,
@@ -385,6 +396,7 @@ def adhoc__reference_dq_checks_failed(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_JSON_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__master_dq_checks_summary(
     adhoc__master_data_quality_checks: sql.DataFrame,
     spark: PySparkResource,
@@ -403,6 +415,7 @@ def adhoc__master_dq_checks_summary(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_silver_geolocation(
     context: OpExecutionContext,
     config: FileConfig,
@@ -468,6 +481,7 @@ def adhoc__publish_silver_geolocation(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_silver_coverage(
     context: OpExecutionContext,
     config: FileConfig,
@@ -533,6 +547,7 @@ def adhoc__publish_silver_coverage(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_master_to_gold(
     context: OpExecutionContext,
     config: FileConfig,
@@ -623,6 +638,7 @@ def adhoc__publish_master_to_gold(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_reference_to_gold(
     context: OpExecutionContext,
     config: FileConfig,
@@ -693,6 +709,7 @@ def adhoc__publish_reference_to_gold(
 
 
 @asset
+@capture_op_exceptions
 async def adhoc__broadcast_master_release_notes(
     context: OpExecutionContext,
     config: FileConfig,

--- a/dagster/src/assets/adhoc/master_dq_checks.py
+++ b/dagster/src/assets/adhoc/master_dq_checks.py
@@ -22,11 +22,13 @@ from src.utils.logger import ContextLoggerWithLoguruFallback
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
 from src.utils.schema import get_schema_columns_datahub
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import OpExecutionContext, Output, asset
 
 
 @asset
+@capture_op_exceptions
 def adhoc__standalone_master_data_quality_checks(
     context: OpExecutionContext,
     config: FileConfig,

--- a/dagster/src/assets/adhoc/qos_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/qos_csv_to_gold.py
@@ -16,6 +16,7 @@ from src.utils.datahub.emit_dataset_metadata import (
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
 from src.utils.schema import get_schema_columns_datahub
+from src.utils.sentry import capture_op_exceptions
 from src.utils.spark import transform_types
 
 from dagster import (
@@ -26,6 +27,7 @@ from dagster import (
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__load_qos_csv(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -36,6 +38,7 @@ def adhoc__load_qos_csv(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__qos_transforms(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -75,6 +78,7 @@ def adhoc__qos_transforms(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_qos_to_gold(
     context: OpExecutionContext,
     adhoc__qos_transforms: sql.DataFrame,

--- a/dagster/src/assets/adhoc/qos_raw_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/qos_raw_csv_to_gold.py
@@ -12,6 +12,7 @@ from src.resources import ResourceKey
 from src.utils.adls import ADLSFileClient
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
+from src.utils.sentry import capture_op_exceptions
 from src.utils.spark import transform_types
 
 from dagster import (
@@ -22,6 +23,7 @@ from dagster import (
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__load_qos_raw_csv(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -32,6 +34,7 @@ def adhoc__load_qos_raw_csv(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__qos_raw_transforms(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -71,6 +74,7 @@ def adhoc__qos_raw_transforms(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def adhoc__publish_qos_raw_to_gold(
     context: OpExecutionContext,
     adhoc__qos_raw_transforms: sql.DataFrame,

--- a/dagster/src/assets/admin/assets.py
+++ b/dagster/src/assets/admin/assets.py
@@ -5,6 +5,7 @@ from pyspark.sql import SparkSession
 from src.constants.constants_class import constants
 from src.settings import settings
 from src.utils.adls import ADLSFileClient
+from src.utils.sentry import capture_op_exceptions
 
 from azure.core.exceptions import ResourceNotFoundError
 from dagster import (
@@ -19,6 +20,7 @@ from dagster import (
 
 
 @asset
+@capture_op_exceptions
 def admin__terminate_all_runs(context: OpExecutionContext):
     runs = [
         r
@@ -49,6 +51,7 @@ class RollbackTableConfig(Config):
 
 
 @asset
+@capture_op_exceptions
 def admin__rollback_table_version(
     _: OpExecutionContext, config: RollbackTableConfig, spark: PySparkResource
 ):
@@ -65,6 +68,7 @@ def admin__rollback_table_version(
 
 
 @asset
+@capture_op_exceptions
 def admin__create_lakehouse_local(
     context: OpExecutionContext, adls_file_client: ADLSFileClient
 ):

--- a/dagster/src/assets/common/assets.py
+++ b/dagster/src/assets/common/assets.py
@@ -43,6 +43,7 @@ from src.utils.schema import (
     get_schema_columns,
     get_schema_columns_datahub,
 )
+from src.utils.sentry import capture_op_exceptions
 from src.utils.spark import compute_row_hash, transform_types
 
 from azure.core.exceptions import ResourceNotFoundError
@@ -50,6 +51,7 @@ from dagster import OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value, deps=["silver"])
+@capture_op_exceptions
 def manual_review_passed_rows(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -70,6 +72,7 @@ def manual_review_passed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def manual_review_failed_rows(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -154,6 +157,7 @@ def manual_review_failed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def silver(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -237,6 +241,7 @@ def silver(
 
 
 @asset(deps=["manual_review_passed_rows", "manual_review_failed_rows"])
+@capture_op_exceptions
 def reset_staging_table(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -296,6 +301,7 @@ def reset_staging_table(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value, deps=["silver"])
+@capture_op_exceptions
 def master(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -383,6 +389,7 @@ def master(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value, deps=["silver"])
+@capture_op_exceptions
 def reference(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -448,6 +455,7 @@ def reference(
 
 
 @asset
+@capture_op_exceptions
 async def broadcast_master_release_notes(
     context: OpExecutionContext,
     config: FileConfig,

--- a/dagster/src/assets/debug/assets.py
+++ b/dagster/src/assets/debug/assets.py
@@ -3,6 +3,7 @@ from httpx import AsyncClient
 from pydantic import Field
 from pyspark.sql import SparkSession
 from src.settings import settings
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import Config, MetadataValue, OpExecutionContext, Output, asset
 
@@ -32,6 +33,7 @@ class GenericEmailRequestConfig(Config):
 
 
 @asset
+@capture_op_exceptions
 def debug__drop_schema(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -43,6 +45,7 @@ def debug__drop_schema(
 
 
 @asset
+@capture_op_exceptions
 def debug__drop_table(
     context: OpExecutionContext,
     spark: PySparkResource,
@@ -54,6 +57,7 @@ def debug__drop_table(
 
 
 @asset
+@capture_op_exceptions
 def debug__test_mlab_db_connection(
     _: OpExecutionContext, config: ExternalDbQueryConfig
 ):
@@ -81,6 +85,7 @@ def debug__test_proco_db_connection(
 
 
 @asset
+@capture_op_exceptions
 def debug__test_connectivity_merge(
     _: OpExecutionContext, config: ExternalDbQueryConfig
 ):
@@ -213,6 +218,7 @@ def debug__test_connectivity_merge(
 
 
 @asset
+@capture_op_exceptions
 async def debug__send_test_email(
     context: OpExecutionContext, config: GenericEmailRequestConfig
 ):

--- a/dagster/src/assets/school_connectivity/assets.py
+++ b/dagster/src/assets/school_connectivity/assets.py
@@ -30,11 +30,13 @@ from src.utils.schema import (
     construct_schema_name_for_tier,
     get_schema_columns_datahub,
 )
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key="adls_pandas_io_manager")
+@capture_op_exceptions
 def qos_school_connectivity_raw(
     context: OpExecutionContext,
     config: FileConfig,
@@ -117,6 +119,7 @@ def qos_school_connectivity_raw(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_bronze(
     context: OpExecutionContext,
     qos_school_connectivity_raw: sql.DataFrame,
@@ -221,6 +224,7 @@ def qos_school_connectivity_bronze(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_data_quality_results(
     context: OpExecutionContext,
     config: FileConfig,
@@ -245,6 +249,7 @@ def qos_school_connectivity_data_quality_results(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_JSON_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_data_quality_results_summary(
     qos_school_connectivity_raw: sql.DataFrame,
     qos_school_connectivity_data_quality_results: sql.DataFrame,
@@ -264,6 +269,7 @@ def qos_school_connectivity_data_quality_results_summary(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_dq_passed_rows(
     qos_school_connectivity_data_quality_results: sql.DataFrame,
     config: FileConfig,
@@ -284,6 +290,7 @@ def qos_school_connectivity_dq_passed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_dq_failed_rows(
     qos_school_connectivity_data_quality_results: sql.DataFrame,
     config: FileConfig,
@@ -304,6 +311,7 @@ def qos_school_connectivity_dq_failed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_connectivity_gold(
     context: OpExecutionContext,
     qos_school_connectivity_dq_passed_rows: sql.DataFrame,

--- a/dagster/src/assets/school_coverage/assets.py
+++ b/dagster/src/assets/school_coverage/assets.py
@@ -50,11 +50,13 @@ from src.utils.schema import (
     get_schema_columns_datahub,
 )
 from src.utils.send_email_dq_report import send_email_dq_report_with_config
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import MetadataValue, OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def coverage_raw(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -72,6 +74,7 @@ def coverage_raw(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def coverage_data_quality_results(
     context: OpExecutionContext,
     config: FileConfig,
@@ -162,6 +165,7 @@ def coverage_data_quality_results(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_JSON_IO_MANAGER.value)
+@capture_op_exceptions
 async def coverage_data_quality_results_summary(
     context: OpExecutionContext,
     config: FileConfig,
@@ -201,6 +205,7 @@ async def coverage_data_quality_results_summary(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def coverage_dq_passed_rows(
     context: OpExecutionContext,
     coverage_data_quality_results: sql.DataFrame,
@@ -232,6 +237,7 @@ def coverage_dq_passed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def coverage_dq_failed_rows(
     context: OpExecutionContext,
     coverage_data_quality_results: sql.DataFrame,
@@ -264,6 +270,7 @@ def coverage_dq_failed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def coverage_bronze(
     context: OpExecutionContext,
     coverage_dq_passed_rows: sql.DataFrame,
@@ -314,6 +321,7 @@ def coverage_bronze(
 
 
 @asset
+@capture_op_exceptions
 def coverage_staging(
     context: OpExecutionContext,
     coverage_bronze: sql.DataFrame,
@@ -356,6 +364,7 @@ def coverage_staging(
 
 
 @asset
+@capture_op_exceptions
 def coverage_delete_staging(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,

--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -51,11 +51,13 @@ from src.utils.schema import (
     get_schema_columns_datahub,
 )
 from src.utils.send_email_dq_report import send_email_dq_report_with_config
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import MetadataValue, OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
+@capture_op_exceptions
 def geolocation_raw(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,
@@ -72,6 +74,7 @@ def geolocation_raw(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def geolocation_bronze(
     context: OpExecutionContext,
     geolocation_raw: bytes,
@@ -176,6 +179,7 @@ def geolocation_bronze(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def geolocation_data_quality_results(
     context: OpExecutionContext,
     config: FileConfig,
@@ -282,6 +286,7 @@ def geolocation_data_quality_results(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_JSON_IO_MANAGER.value)
+@capture_op_exceptions
 async def geolocation_data_quality_results_summary(
     context: OpExecutionContext,
     geolocation_bronze: sql.DataFrame,
@@ -316,6 +321,7 @@ async def geolocation_data_quality_results_summary(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def geolocation_dq_passed_rows(
     context: OpExecutionContext,
     geolocation_data_quality_results: sql.DataFrame,
@@ -350,6 +356,7 @@ def geolocation_dq_passed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def geolocation_dq_failed_rows(
     context: OpExecutionContext,
     geolocation_data_quality_results: sql.DataFrame,
@@ -385,6 +392,7 @@ def geolocation_dq_failed_rows(
 
 
 @asset
+@capture_op_exceptions
 def geolocation_staging(
     context: OpExecutionContext,
     geolocation_dq_passed_rows: sql.DataFrame,
@@ -427,6 +435,7 @@ def geolocation_staging(
 
 
 @asset
+@capture_op_exceptions
 def geolocation_delete_staging(
     context: OpExecutionContext,
     adls_file_client: ADLSFileClient,

--- a/dagster/src/assets/school_list/assets.py
+++ b/dagster/src/assets/school_list/assets.py
@@ -39,11 +39,13 @@ from src.utils.schema import (
     get_schema_columns,
     get_schema_columns_datahub,
 )
+from src.utils.sentry import capture_op_exceptions
 
 from dagster import OpExecutionContext, Output, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_raw(
     context: OpExecutionContext, config: FileConfig
 ) -> Output[pd.DataFrame]:
@@ -69,6 +71,7 @@ def qos_school_list_raw(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_bronze(
     qos_school_list_raw: sql.DataFrame,
     config: FileConfig,
@@ -121,6 +124,7 @@ def qos_school_list_bronze(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_data_quality_results(
     context: OpExecutionContext,
     config: FileConfig,
@@ -166,6 +170,7 @@ def qos_school_list_data_quality_results(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_JSON_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_data_quality_results_summary(
     qos_school_list_bronze: sql.DataFrame,
     qos_school_list_data_quality_results: sql.DataFrame,
@@ -188,6 +193,7 @@ def qos_school_list_data_quality_results_summary(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_dq_passed_rows(
     qos_school_list_data_quality_results: sql.DataFrame,
     config: FileConfig,
@@ -220,6 +226,7 @@ def qos_school_list_dq_passed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PANDAS_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_dq_failed_rows(
     qos_school_list_data_quality_results: sql.DataFrame,
     config: FileConfig,
@@ -241,6 +248,7 @@ def qos_school_list_dq_failed_rows(
 
 
 @asset(io_manager_key=ResourceKey.ADLS_DELTA_IO_MANAGER.value)
+@capture_op_exceptions
 def qos_school_list_staging(
     context: OpExecutionContext,
     qos_school_list_dq_passed_rows: sql.DataFrame,

--- a/dagster/src/spark/udf_dependencies.py
+++ b/dagster/src/spark/udf_dependencies.py
@@ -4,9 +4,9 @@ import pandas as pd
 from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 from loguru import logger
+from shapely.errors import GEOSException
 from shapely.geometry import Point
 from shapely.ops import nearest_points
-from shapely.errors import GEOSException
 
 
 def get_point(longitude: float, latitude: float) -> None | Point:


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary

Currently, Sentry is only attached to assets related to schema migrations, namely `initialize_metaschema` and `migrate_schema`. This change attaches Sentry to all assets such that it will capture all exceptions happening in the pipelines.

## How to test

Intentionally cause an exception in one of the pipelines. It should be visible in your Sentry dashboard.
