### PR TITLE
fix: use custom type instead of union

### DIFF
--- a/dagster/src/assets/adhoc/master_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/master_csv_to_gold.py
@@ -49,7 +49,7 @@ from src.utils.schema import (
 from src.utils.spark import compute_row_hash, transform_types
 
 from azure.core.exceptions import ResourceNotFoundError
-from dagster import OpExecutionContext, Output, asset
+from dagster import OpExecutionContext, Output, PythonObjectDagsterType, asset
 
 
 @asset(io_manager_key=ResourceKey.ADLS_PASSTHROUGH_IO_MANAGER.value)
@@ -389,7 +389,7 @@ def adhoc__master_dq_checks_summary(
     adhoc__master_data_quality_checks: sql.DataFrame,
     spark: PySparkResource,
     config: FileConfig,
-) -> dict | list[dict]:
+) -> PythonObjectDagsterType(python_type=(dict, list)):
     df_summary = aggregate_report_json(
         df_aggregated=aggregate_report_spark_df(
             spark.spark_session,

--- a/dagster/src/spark/udf_dependencies.py
+++ b/dagster/src/spark/udf_dependencies.py
@@ -4,9 +4,9 @@ import pandas as pd
 from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 from loguru import logger
+from shapely.errors import GEOSException
 from shapely.geometry import Point
 from shapely.ops import nearest_points
-from shapely.errors import GEOSException
 
 
 def get_point(longitude: float, latitude: float) -> None | Point:


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Currently, Dagster does not allow the use of the Union `|` operator in function return types. This can sometimes cause the repository to fail to load due to the below error

```
dagster._core.errors.DagsterInvalidDefinitionError: Problem using type 'dict | list[dict]' from return type annotation, correct the issue or explicitly set the dagster_type via Out().
```

[Reference issue
](https://github.com/dagster-io/dagster/issues/14368)