### PR TITLE
fix: disable use of geopy in country boundary checks

### DIFF
--- a/dagster/src/spark/udf_dependencies.py
+++ b/dagster/src/spark/udf_dependencies.py
@@ -4,9 +4,9 @@ import pandas as pd
 from geopy.distance import geodesic
 from geopy.geocoders import Nominatim
 from loguru import logger
+from shapely.errors import GEOSException
 from shapely.geometry import Point
 from shapely.ops import nearest_points
-from shapely.errors import GEOSException
 
 
 def get_point(longitude: float, latitude: float) -> None | Point:

--- a/dagster/src/spark/user_defined_functions.py
+++ b/dagster/src/spark/user_defined_functions.py
@@ -10,9 +10,7 @@ from pyspark.sql.functions import pandas_udf, udf
 from src.spark.config_expectations import config
 
 from .udf_dependencies import (
-    boundary_distance,
     is_within_boundary_distance,
-    is_within_country_geopy,
     is_within_country_mapbox,
 )
 
@@ -82,11 +80,6 @@ def is_not_within_country_check_udf_factory(
         if is_within_boundary_distance(
             latitude, longitude, geometry, dq_is_not_within_country
         ):
-            return 0
-        if (
-            boundary_distance(latitude, longitude, geometry)
-            <= BOUNDARY_DISTANCE_THRESHOLD
-        ) and is_within_country_geopy(latitude, longitude, country_code_iso2):
             return 0
 
         return 1


### PR DESCRIPTION
## What type of PR is this?

- `fix`: disable the use of geopy in the country boundary check

## Summary
This means these checks will be entirely based on the mapbox boundaries making them more consistent with mapbox

What does this PR do
Removes the geopy country boundary check that uses open street map's Nomatim reverse geocoder
