### PR TITLE
fix: use base instead of silver schema in geolocation_bronze

### DIFF
--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -113,29 +113,8 @@ def geolocation_bronze(
 
     schema = StructType(columns)
 
-    if check_table_exists(s, schema_name, country_code, DataTier.SILVER):
-        context.log.info("TABLE EXISTS")
-        silver_tier_schema_name = construct_schema_name_for_tier(
-            "school_geolocation", DataTier.SILVER
-        )
-        silver_table_name = construct_full_table_name(
-            silver_tier_schema_name, country_code
-        )
-        silver = DeltaTable.forName(s, silver_table_name).alias("silver").toDF()
-    else:
-        context.log.info("TABLE DOES NOT EXIST")
-
-        silver = s.createDataFrame(s.sparkContext.emptyRDD(), schema=schema)
-
-    casted_silver = silver.withColumn(
-        "school_id_govt",
-        f.when(
-            f.col("school_id_govt").cast(LongType()).isNotNull(),
-            f.col("school_id_govt").cast(LongType()).cast(StringType()),
-        ).otherwise(f.col("school_id_govt").cast(StringType())),
-    )
-    context.log.info("Casted Silver")
-    context.log.info(casted_silver)
+    # Create empty base schema DataFrame
+    base_schema_df = s.createDataFrame(s.sparkContext.emptyRDD(), schema=schema)
 
     casted_bronze = df.withColumn(
         "school_id_govt",
@@ -147,7 +126,7 @@ def geolocation_bronze(
     context.log.info("Casted Bronze")
     context.log.info(casted_bronze)
 
-    df = create_bronze_layer_columns(casted_bronze, casted_silver, country_code)
+    df = create_bronze_layer_columns(casted_bronze, base_schema_df, country_code)
     context.log.info("DF from create_bronze_layer_columns")
     context.log.info(df)
 


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Resolves GIGA-18, where columns that are in the raw DF but not in `school_geolocation_silver.[country]` nor `schemas.school_geolocation` are outputted by the `geolocation_bronze` asset.

Instead of using the `school_geolocation_silver.[country]` as reference, we can just use the base `schemas.school_geolocation`. The downstream `silver` asset should be able to merge any new columns such that it syncs with the base schema.

## How to test

* Try uploading a geolocation file with columns that are not in `schemas.school_geolocation`. `geolocation_bronze` should not output any columns not in the schema.
* Upload geolocation data for a country once. Add a new column to `schemas.school_geolocation` then do another upload with the new column. It should still be able to merge the changes up to the gold tables.