### PR TITLE
fix: truncate empty outputs of ADLSDeltaIOManager

### DIFF
--- a/dagster/src/assets/common/assets.py
+++ b/dagster/src/assets/common/assets.py
@@ -230,6 +230,12 @@ def silver(
     else:
         new_silver = df_passed
 
+    if new_silver.isEmpty():
+        context.log.info(
+            "Silver table is empty after merge, returning empty DataFrame."
+        )
+        new_silver = s.createDataFrame([], schema=schema_columns)
+
     schema_reference = get_schema_columns_datahub(s, schema_name)
     datahub_emit_metadata_with_exception_catcher(
         context=context,

--- a/dagster/src/resources/io_managers/adls_delta.py
+++ b/dagster/src/resources/io_managers/adls_delta.py
@@ -31,17 +31,19 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
     def handle_output(self, context: OutputContext, output: sql.DataFrame | None):
         context.log.info("Handling DeltaIOManager output...")
         if output is None:
-            return
-        if output.isEmpty():
+            context.log.info("Output is None, skipping execution.")
             return
 
         config = FileConfig(**context.step_context.op_config)
-        table_name, _, _ = self._get_table_path(context)
+        table_name, table_root_path, table_path = self._get_table_path(context)
         schema_tier_name = construct_schema_name_for_tier(
             config.metastore_schema, config.tier
         )
         full_table_name = f"{schema_tier_name}.{table_name}"
         context.log.info(f"Full table name: {full_table_name}")
+
+        if self._handle_truncate(context, output, config, full_table_name):
+            return
 
         self._create_schema_if_not_exists(schema_tier_name)
         self._create_table_if_not_exists(context, output, schema_tier_name, table_name)
@@ -245,3 +247,41 @@ class ADLSDeltaIOManager(BaseConfigurableIOManager):
             .partitionBy(*partition_columns)
             .saveAsTable(full_table_name)
         )
+
+    def _handle_truncate(
+        self,
+        context: OutputContext,
+        output: sql.DataFrame,
+        config: FileConfig,
+        full_table_name: str,
+    ) -> bool:
+        """Handles truncation of a table's contents if conditions are met.
+
+        Returns:
+            bool: True if truncation was performed, False otherwise
+        """
+        truncate_schemas = [
+            "school_coverage",
+            "school_geolocation",
+            "school_master",
+            "school_reference",
+        ]
+
+        if (
+            output.isEmpty()
+            and config.metastore_schema in truncate_schemas
+            and "adhoc" not in context.asset_key.path[-1]
+        ):
+            context.log.info(
+                f"Output is empty, clearing all data from {full_table_name}"
+            )
+
+            empty_df = self._get_spark_session().createDataFrame([], output.schema)
+
+            self._overwrite_data(
+                empty_df, config.metastore_schema, full_table_name, context
+            )
+
+            context.log.info(f"Successfully cleared all data from {full_table_name}")
+            return True
+        return False


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary
Currently, only partial deletes to datasets are written by `ADLSDeltaIOManager`. This fix allows for full table deletes to be done via Giga Sync.

## How to test

Mark all row IDs for deletion via Giga Sync. Check if the tables have actually written the deletes after the pipeline executes.
