### PR TITLE
fix: correct connectivity logic when download speed is null

### DIFF
--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -641,7 +641,10 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
             (f.lower(f.col("connectivity_RT")) == "yes")
             | (
                 (f.lower(f.col("connectivity_govt")) == "yes")
-                & (f.col("download_speed_govt") != 0)
+                & (
+                    (f.col("download_speed_govt") != 0)
+                    | f.col("download_speed_govt").isNull()
+                )
             )
             | (f.col("download_speed_govt") > 0),
             "Yes",
@@ -649,6 +652,11 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
         .when((f.lower(f.col("connectivity_govt")).isNull()), "Unknown")
         .otherwise("No"),
     )
+
+    master = master.withColumn(
+        "connectivity_govt", f.initcap(f.col("connectivity_govt"))
+    )
+
     return master.withColumn(
         "connectivity_RT", f.coalesce(f.col("connectivity_RT"), f.lit("No"))
     )


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

What does this PR do
Ensures that when `download_speed_govt` is null, it doesn't affect the value of `connectivity`
