### PR TITLE
Fix/fix connectivity logic for updates

### DIFF
--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -236,32 +236,12 @@ def geolocation_bronze(
     config.metadata.update({"column_mapping": column_mapping})
     context.log.info("After config metadata update")
 
-    # if mode == UploadMode.CREATE.value:
-    #     connectivity_related_cols = [
-    #         "download_speed_govt",
-    #         "connectivity_govt",
-    #         "connectivity_type_govt",
-    #     ]
-    #     for column in connectivity_related_cols:
-    #         if column not in df.columns:
-    #             df = df.withColumn(column, f.lit(None))
-
     if settings.DEPLOY_ENV != DeploymentEnvironment.LOCAL:
         # QoS Columns
         coco = CountryConverter()
         country_code_2 = coco.convert(country_code, to="ISO2")
         connectivity = connectivity_rt_dataset(s, country_code_2)
         df = merge_connectivity_to_df(df, connectivity, uploaded_columns, mode)
-
-    # if mode == UploadMode.UPDATE.value:
-    #     if 'connectivity_govt' in df.columns and df.connectivity_govt.isNull().sum():
-    #         silver_connectivity = DeltaTable.forName().toDF().select('school_id_giga', 'connectivity_govt')
-    #         silver_connectivity = silver_connectivity.withColumnRenamed()
-    #         # join to master
-    #         # coalesce with master
-    #         # get final column
-    #
-    #         # use silver to coalesce values
 
     # standardize the connectivity type
     if "connectivity_type_govt" in uploaded_columns:

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -636,7 +636,7 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
 
     master = master.join(connectivity, on="school_id_giga", how="left")
 
-    if set("download_speed_govt", "connectivity_govt").issubset(set(df.columns)):
+    if {"download_speed_govt", "connectivity_govt"}.issubset(set(df.columns)):
         # this block will run when we create schools or during updates if both download_speed_govt
         # and connectivity_govt re provided
         master = master.withColumn(

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -636,7 +636,7 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
 
     master = master.join(connectivity, on="school_id_giga", how="left")
 
-    if {"download_speed_govt", "connectivity_govt"}.issubset(set(df.columns)):
+    if {"download_speed_govt", "connectivity_govt"}.issubset(set(master.columns)):
         # this block will run when we create schools or during updates if both download_speed_govt
         # and connectivity_govt re provided
         master = master.withColumn(
@@ -656,7 +656,7 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
             .when((f.lower(f.col("connectivity_govt")).isNull()), "Unknown")
             .otherwise("No"),
         )
-    elif "connectivity_govt" in df.columns:
+    elif "connectivity_govt" in master.columns:
         # this will run during updates if only connectivity_govt is provided
         master = master.withColumn(
             "connectivity",
@@ -665,7 +665,7 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
             ),
             "No",
         )
-    elif "download_speed_govt" in df.columns:
+    elif "download_speed_govt" in master.columns:
         # this will run during updates if only connectivity_govt is provided
         master = master.withColumn(
             "connectivity",
@@ -675,7 +675,7 @@ def merge_connectivity_to_master(master: sql.DataFrame, connectivity: sql.DataFr
         )
 
     # sanitize connectivity_govt if provided
-    if "connectivity_govt" in df.columns:
+    if "connectivity_govt" in master.columns:
         master = master.withColumn(
             "connectivity_govt", f.initcap(f.trim(f.col("connectivity_govt")))
         )

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -660,7 +660,7 @@ def merge_connectivity_to_master(
             )
             .when(
                 (f.lower(f.col("connectivity_govt")).isNull()),
-                f.when(mode == UploadMode.UPDATE.value, None).otherwise("Unknown"),
+                f.lit(None) if mode == UploadMode.UPDATE.value else f.lit("Unknown"),
             )
             .otherwise("No"),
         )


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

What does this PR do
Fixes issue with the `connectivity` field due to conditions not being explicitly defined. In particular, it removes ambiguity about what happens in different scenarios when schools are being updated and:

1. Prevents the `connectivity` and `connectivity_govt` fields from being updated if they are not in the data
2. Ensures that `connectivity` is already updated in a predictable manner regardless of which fields are provided
3. Fixes a bug that resulted in `connectivity_type`, `connectivity_type_govt` and `connectivity` being updated when they are not in the data

Details on how connectivity is updated are here:
https://app.clickup.com/25789471/v/dc/rk10z-3444/rk10z-41957
