### PR TITLE
fix: prevent overwrite of existing values during update

### DIFF
--- a/dagster/src/assets/adhoc/custom_dataset.py
+++ b/dagster/src/assets/adhoc/custom_dataset.py
@@ -6,9 +6,9 @@ from numpy import nan
 from pyspark import sql
 from pyspark.sql import (
     SparkSession,
+    functions as F,
 )
 from pyspark.sql.types import NullType
-from pyspark.sql import functions as F
 from src.resources import ResourceKey
 from src.utils.adls import ADLSFileClient
 from src.utils.metadata import get_output_metadata, get_table_preview
@@ -44,10 +44,10 @@ def custom_dataset_bronze(
         buffer.seek(0)
         pdf = pd.read_csv(buffer)
 
-    for col in pdf.select_dtypes(include='object').columns:
-        pdf[col] = pdf[col].fillna('').astype(str).replace('', None)
+    for col in pdf.select_dtypes(include="object").columns:
+        pdf[col] = pdf[col].fillna("").astype(str).replace("", None)
 
-    for col in pdf.select_dtypes(include=['number']).columns:
+    for col in pdf.select_dtypes(include=["number"]).columns:
         pdf[col] = pdf[col].astype(float).replace(nan, None)
 
     pdf = pdf.drop_duplicates()
@@ -55,7 +55,9 @@ def custom_dataset_bronze(
 
     context.log.info("original schema")
     context.log.info(df.schema.simpleString())
-    void_columns = [field.name for field in df.schema.fields if isinstance(field.dataType, NullType)]
+    void_columns = [
+        field.name for field in df.schema.fields if isinstance(field.dataType, NullType)
+    ]
 
     for col in void_columns:
         context.log.info(f"{col}")

--- a/dagster/src/assets/adhoc/master_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/master_csv_to_gold.py
@@ -13,6 +13,7 @@ from pyspark.sql import (
     functions as f,
 )
 from pyspark.sql.types import NullType, StructType
+from sqlalchemy import update
 from src.constants import DataTier
 from src.data_quality_checks.utils import (
     aggregate_report_json,
@@ -22,7 +23,6 @@ from src.data_quality_checks.utils import (
     extract_school_id_govt_duplicates,
     row_level_checks,
 )
-from sqlalchemy import update
 from src.internal.common_assets.master_release_notes import (
     send_master_release_notes,
 )
@@ -742,15 +742,16 @@ async def adhoc__reset_geolocation_staging_table(
     )
     context.log.info(f"{staging_table_exists=}")
 
+    staging_table_name = construct_full_table_name(
+        staging_tier_schema_name, country_code
+    )
+
     if not staging_table_exists:
         context.log.info(
             f"Staging table {staging_table_name} does not exist. Skipping reset."
         )
         return None
 
-    staging_table_name = construct_full_table_name(
-        staging_tier_schema_name, country_code
-    )
     staging_table_path = config.destination_filepath
     silver_tier_schema_name = construct_schema_name_for_tier(
         f"school_{dataset_type}", DataTier.SILVER

--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -245,7 +245,7 @@ def geolocation_bronze(
 
     # standardize the connectivity type
     if "connectivity_type_govt" in uploaded_columns:
-        df = standardize_connectivity_type(df)
+        df = standardize_connectivity_type(df, mode)
 
     datahub_emit_metadata_with_exception_catcher(
         context=context,

--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -228,7 +228,7 @@ def geolocation_bronze(
     context.log.info(casted_bronze)
 
     df = create_bronze_layer_columns(
-        casted_bronze, casted_geolocation_base, country_code
+        casted_bronze, casted_geolocation_base, country_code, mode, uploaded_columns
     )
     context.log.info("DF from create_bronze_layer_columns")
     context.log.info(df)

--- a/dagster/src/sensors/adhoc.py
+++ b/dagster/src/sensors/adhoc.py
@@ -173,6 +173,18 @@ def school_master__gold_csv_to_deltatable_sensor(
                 metastore_schema=reference_metastore_schema,
                 tier=DataTier.GOLD,
             ),
+            "adhoc__reset_geolocation_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                metastore_schema="school_geolocation",
+                tier=DataTier.STAGING,
+            ),
+            "adhoc__reset_coverage_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                metastore_schema="school_coverage",
+                tier=DataTier.STAGING,
+            ),
             "adhoc__broadcast_master_release_notes": OpDestinationMapping(
                 source_filepath=f"{constants.gold_folder}/dq-results/school-master/passed/{stem}.csv",
                 destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/{master_metastore_schema}.db/{country_code}",

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -125,13 +125,6 @@ def create_education_level(
             "education_level", mapped_column[f.col("education_level_govt")]
         )
 
-    df = df.withColumn(
-        "education_level",
-        f.when(
-            f.isnan(f.col("education_level")), f.lit(None).cast(StringType())
-        ).otherwise(f.col("education_level")),
-    )
-
     if mode == UploadMode.CREATE.value:
         df = df.withColumns(
             {
@@ -142,6 +135,14 @@ def create_education_level(
                     f.col("education_level"), f.lit("Unknown")
                 ),
             }
+        )
+
+    for column in ("education_level", "education_level_govt"):
+        df = df.withColumn(
+            column,
+            f.when(f.isnan(f.col(column)), f.lit(None).cast(StringType())).otherwise(
+                f.col(column)
+            ),
         )
 
     return df

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -127,8 +127,10 @@ def create_education_level(
 
     df = df.withColumn(
         "education_level",
-        f.when(f.isnan(f.col("education_level")), f.lit(None).cast(StringType())),
-    ).otherwise(f.col("education_level"))
+        f.when(
+            f.isnan(f.col("education_level")), f.lit(None).cast(StringType())
+        ).otherwise(f.col("education_level")),
+    )
 
     if mode == UploadMode.CREATE.value:
         df = df.withColumns(

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -387,6 +387,17 @@ def create_bronze_layer_columns(
         )
         df = add_disputed_region_column(df=df)
 
+        missing_location_condition = (
+            f.col("latitude").isNull() | f.col("longitide").isNull()
+        )
+        for column in ("admin1", "admin1_id_giga", "admin2", "admin2_id_giga"):
+            df = df.withColumn(
+                column,
+                f.when(missing_location_condition, f.lit(None)).otherwise(
+                    f.col(column)
+                ),
+            )
+
     return df
 
 

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -87,7 +87,7 @@ def create_school_id_giga(df: sql.DataFrame) -> sql.DataFrame:
     return df.drop("identifier_concat")
 
 
-def create_education_level(df: sql.DataFrame) -> sql.DataFrame:
+def create_education_level(df: sql.DataFrame, mode: str) -> sql.DataFrame:
     education_level_govt_mapping = {
         # None : "Unknown",
         "Other": "Unknown",
@@ -123,15 +123,19 @@ def create_education_level(df: sql.DataFrame) -> sql.DataFrame:
             "education_level", mapped_column[f.col("education_level_govt")]
         )
 
-    # fill nulls with "Unknown"
-    return df.withColumns(
-        {
-            "education_level_govt": f.coalesce(
-                f.col("education_level_govt"), f.lit("Unknown")
-            ),
-            "education_level": f.coalesce(f.col("education_level"), f.lit("Unknown")),
-        }
-    )
+    if mode == UploadMode.CREATE.value:
+        df = df.withColumns(
+            {
+                "education_level_govt": f.coalesce(
+                    f.col("education_level_govt"), f.lit("Unknown")
+                ),
+                "education_level": f.coalesce(
+                    f.col("education_level"), f.lit("Unknown")
+                ),
+            }
+        )
+
+    return df
 
 
 def create_uzbekistan_school_name(df: sql.DataFrame) -> sql.DataFrame:
@@ -287,6 +291,8 @@ def create_bronze_layer_columns(
     df: sql.DataFrame,
     silver: sql.DataFrame,
     country_code_iso3: str,
+    mode: str,
+    uploaded_columns: list[str],
     is_qos: bool = False,
 ) -> sql.DataFrame:
     """Create bronze layer columns with optional QoS-specific handling.
@@ -332,12 +338,17 @@ def create_bronze_layer_columns(
     df = joined_df.select(*select_expr)
 
     # standardize education level
-    df = create_education_level(df)
-    df = create_school_id_giga(df)
-    df = df.withColumn(
-        "school_id_govt_type",
-        f.coalesce(f.col("school_id_govt_type"), f.lit("Unknown")),
-    )
+    if mode == UploadMode.CREATE.value or "education_level_govt" in uploaded_columns:
+        df = create_education_level(df)
+
+    if mode == UploadMode.CREATE.value:
+        df = create_school_id_giga(df)
+
+    if mode == UploadMode.CREATE.value or "school_id_govt_type" in uploaded_columns:
+        df = df.withColumn(
+            "school_id_govt_type",
+            f.coalesce(f.col("school_id_govt_type"), f.lit("Unknown")),
+        )
 
     # Admin mapbox columns
     df = add_admin_columns(
@@ -352,14 +363,7 @@ def create_bronze_layer_columns(
     )
     df = add_disputed_region_column(df=df)
 
-    # Add ingestion timestamp
-    return df.withColumn(
-        "connectivity_govt_ingestion_timestamp",
-        f.when(
-            f.col("connectivity_govt_ingestion_timestamp").isNull(),
-            f.current_timestamp(),
-        ),
-    )
+    return df
 
 
 def get_admin_boundaries(
@@ -641,6 +645,10 @@ def merge_connectivity_to_master(
 
     master = master.join(connectivity, on="school_id_giga", how="left")
 
+    master = master.withColumn(
+        "connectivity_RT", f.coalesce(f.col("connectivity_RT"), f.lit("No"))
+    )
+
     # make sure connectivity_govt is standardized
     master = master.withColumn(
         "connectivity_govt",
@@ -649,6 +657,7 @@ def merge_connectivity_to_master(
         ).otherwise(f.initcap(f.trim(f.col("connectivity_govt")))),
     )
 
+    # determine the value of connectivity
     if mode == UploadMode.CREATE.value or {
         "download_speed_govt",
         "connectivity_govt",
@@ -693,8 +702,12 @@ def merge_connectivity_to_master(
             .otherwise(f.lit(None).cast(StringType())),
         )
 
+    # add the time connectivity_govt was ingested
     master = master.withColumn(
-        "connectivity_RT", f.coalesce(f.col("connectivity_RT"), f.lit("No"))
+        "connectivity_govt_ingestion_timestamp",
+        f.when(f.col("connectivity_govt").isNotNull(), f.current_timestamp()).otherwise(
+            f.lit(None).cast(TimestampType())
+        ),
     )
 
     return master

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -366,7 +366,7 @@ def create_bronze_layer_columns(
 
     # standardize education level
     if mode == UploadMode.CREATE.value or "education_level_govt" in uploaded_columns:
-        df = create_education_level(df, uploaded_columns)
+        df = create_education_level(df, mode, uploaded_columns)
 
     df = create_school_id_giga(df)
 

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -403,9 +403,9 @@ def create_bronze_layer_columns(
         for column in ("admin1", "admin1_id_giga", "admin2", "admin2_id_giga"):
             df = df.withColumn(
                 column,
-                f.when(missing_location_condition, f.lit(None)).otherwise(
-                    f.col(column)
-                ),
+                f.when(
+                    missing_location_condition, f.lit(None).cast(StringType())
+                ).otherwise(f.col(column)),
             )
 
     return df
@@ -674,7 +674,7 @@ def connectivity_rt_dataset(
     logger.info(out.schema)
     return out
 
- 
+
 def merge_connectivity_to_master(
     master: sql.DataFrame,
     connectivity: sql.DataFrame,

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -122,6 +122,11 @@ def create_education_level(df: sql.DataFrame, mode: str) -> sql.DataFrame:
         df = df.withColumn(
             "education_level", mapped_column[f.col("education_level_govt")]
         )
+        df = df.withColumn(
+            "education_level",
+            f.isnan(f.col("education_level")),
+            f.lit(None).cast(StringType()),
+        )
 
     if mode == UploadMode.CREATE.value:
         df = df.withColumns(

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -374,17 +374,18 @@ def create_bronze_layer_columns(
         )
 
     # Admin mapbox columns
-    df = add_admin_columns(
-        df=df,
-        country_code_iso3=country_code_iso3,
-        admin_level="admin1",
-    )
-    df = add_admin_columns(
-        df=df,
-        country_code_iso3=country_code_iso3,
-        admin_level="admin2",
-    )
-    df = add_disputed_region_column(df=df)
+    if "latitude" in uploaded_columns and "longitude" in uploaded_columns:
+        df = add_admin_columns(
+            df=df,
+            country_code_iso3=country_code_iso3,
+            admin_level="admin1",
+        )
+        df = add_admin_columns(
+            df=df,
+            country_code_iso3=country_code_iso3,
+            admin_level="admin2",
+        )
+        df = add_disputed_region_column(df=df)
 
     return df
 

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -127,9 +127,8 @@ def create_education_level(
 
     df = df.withColumn(
         "education_level",
-        f.isnan(f.col("education_level")),
-        f.lit(None).cast(StringType()),
-    )
+        f.when(f.isnan(f.col("education_level")), f.lit(None).cast(StringType())),
+    ).otherwise(f.col("education_level"))
 
     if mode == UploadMode.CREATE.value:
         df = df.withColumns(

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -397,7 +397,7 @@ def create_bronze_layer_columns(
         df = add_disputed_region_column(df=df)
 
         missing_location_condition = (
-            f.col("latitude").isNull() | f.col("longitide").isNull()
+            f.col("latitude").isNull() | f.col("longitude").isNull()
         )
         for column in ("admin1", "admin1_id_giga", "admin2", "admin2_id_giga"):
             df = df.withColumn(


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

During an update, some key values get recalculated including:

- `education level`
- `connectivity` (handled in a different PR)
- `connectivity_govt_ingestion_timestamp`
- `connectivity_type`
- `school_id_govt_type`

Since updates typically contain only a portion of the data, this can results in erroneous updates for example, education_level will get populated with "Unknown" if it wasn't provided in the update.

`school_id_giga` is also re-created but this will be handled later

## How to test

Update files via Giga sync that update parts of the data