### PR TITLE
feat: bulk ingestion staging table reset

### DIFF
--- a/dagster/src/sensors/adhoc.py
+++ b/dagster/src/sensors/adhoc.py
@@ -173,6 +173,18 @@ def school_master__gold_csv_to_deltatable_sensor(
                 metastore_schema=reference_metastore_schema,
                 tier=DataTier.GOLD,
             ),
+            "adhoc__reset_geolocation_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                metastore_schema="school_geolocation",
+                tier=DataTier.STAGING,
+            ),
+            "adhoc__reset_coverage_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                metastore_schema="school_coverage",
+                tier=DataTier.STAGING,
+            ),
             "adhoc__broadcast_master_release_notes": OpDestinationMapping(
                 source_filepath=f"{constants.gold_folder}/dq-results/school-master/passed/{stem}.csv",
                 destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/{master_metastore_schema}.db/{country_code}",


### PR DESCRIPTION
## Summary

This PR fixes the issue detailed below:

> In prod an issue was raised wherein the staging table seems to be in a hanging state causing miscounts in the reported number of rows. This can be explained by the following:
> 
> `reset_staging_table` materializes in the post-approval run
> 
> reset drops the staging table, recreates it and copies the contents of silver
> 
> after this post approval run in staging, silver and master contained 152,214 rows
> 
> due to issues caused by the connectivity columns, a backend update was performed rolling back master and silver to 148,323 rows
> 
> at this point `geolocation_staging` still has 152,214 rows
> 
> when the ingestion was retried the system detected the difference between silver and staging and that appeared in the summary
> 
> 
> 
> Changes are required so that `reset_staging_table` happens in bulk ingestions.

## How to test

1. Access giga sync and upload a school geolocation or coverage file.
2. Perform a backend update
3. Via Superset, check the row counts for staging and silver
4. Expect staging table has the same row count as silver
5. Retry the ingestion from step 1
6. Expect row counts to match
 
