### PR TITLE
feat: bulk ingestion staging table reset

### DIFF
--- a/dagster/src/assets/adhoc/master_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/master_csv_to_gold.py
@@ -6,12 +6,14 @@ import pandas as pd
 from dagster_pyspark import PySparkResource
 from datahub.specific.dataset import DatasetPatchBuilder
 from delta import DeltaTable
+from models.approval_requests import ApprovalRequest
 from pyspark import sql
 from pyspark.sql import (
     SparkSession,
     functions as f,
 )
 from pyspark.sql.types import NullType, StructType
+from sqlalchemy import update
 from src.constants import DataTier
 from src.data_quality_checks.utils import (
     aggregate_report_json,
@@ -38,11 +40,19 @@ from src.utils.datahub.emit_dataset_metadata import (
 )
 from src.utils.datahub.emit_lineage import emit_lineage_base
 from src.utils.datahub.emitter import get_rest_emitter
-from src.utils.delta import check_table_exists, sync_schema
+from src.utils.db.primary import get_db_context
+from src.utils.delta import (
+    check_table_exists,
+    create_delta_table,
+    create_schema,
+    sync_schema,
+)
 from src.utils.logger import ContextLoggerWithLoguruFallback
 from src.utils.metadata import get_output_metadata, get_table_preview
 from src.utils.op_config import FileConfig
 from src.utils.schema import (
+    construct_full_table_name,
+    construct_schema_name_for_tier,
     get_schema_columns,
     get_schema_columns_datahub,
 )
@@ -706,6 +716,160 @@ def adhoc__publish_reference_to_gold(
             "preview": get_table_preview(gold),
         },
     )
+
+
+@asset(deps=["adhoc__publish_silver_geolocation"])
+@capture_op_exceptions
+async def adhoc__reset_geolocation_staging_table(
+    context: OpExecutionContext,
+    spark: PySparkResource,
+    config: FileConfig,
+    adls_file_client: ADLSFileClient,
+) -> None:
+    s: SparkSession = spark.spark_session
+    country_code = config.country_code
+    dataset_type = "geolocation"
+    staging_tier_schema_name = construct_schema_name_for_tier(
+        f"school_{dataset_type}", DataTier.STAGING
+    )
+
+    # Check if staging table exists
+    staging_table_exists = check_table_exists(
+        spark=s,
+        schema_name=config.metastore_schema,
+        table_name=country_code.lower(),
+        data_tier=DataTier.STAGING,
+    )
+    context.log.info(f"{staging_table_exists=}")
+
+    if not staging_table_exists:
+        context.log.info(
+            f"Staging table {staging_table_name} does not exist. Skipping reset."
+        )
+        return None
+
+    staging_table_name = construct_full_table_name(
+        staging_tier_schema_name, country_code
+    )
+    staging_table_path = config.destination_filepath
+    silver_tier_schema_name = construct_schema_name_for_tier(
+        f"school_{dataset_type}", DataTier.SILVER
+    )
+    silver_table_name = construct_full_table_name(silver_tier_schema_name, country_code)
+
+    s.sql(f"DROP TABLE IF EXISTS {staging_table_name}")
+
+    try:
+        adls_file_client.delete(staging_table_path, is_directory=True)
+    except ResourceNotFoundError as e:
+        context.log.warning(e)
+
+    schema_columns = get_schema_columns(s, config.metastore_schema)
+    silver = DeltaTable.forName(s, silver_table_name).alias("silver").toDF()
+    create_schema(s, staging_tier_schema_name)
+    create_delta_table(
+        s,
+        staging_tier_schema_name,
+        country_code,
+        schema_columns,
+        context,
+        if_not_exists=True,
+    )
+    silver.write.format("delta").mode("append").saveAsTable(staging_table_name)
+
+    formatted_dataset = f"School {dataset_type.capitalize()}"
+    with get_db_context() as db:
+        with db.begin():
+            db.execute(
+                update(ApprovalRequest)
+                .where(
+                    (ApprovalRequest.country == country_code)
+                    & (ApprovalRequest.dataset == formatted_dataset)
+                )
+                .values(
+                    {
+                        ApprovalRequest.is_merge_processing: False,
+                        ApprovalRequest.enabled: False,
+                    }
+                )
+            )
+
+
+@asset(deps=["adhoc__publish_silver_coverage"])
+@capture_op_exceptions
+async def adhoc__reset_coverage_staging_table(
+    context: OpExecutionContext,
+    spark: PySparkResource,
+    config: FileConfig,
+    adls_file_client: ADLSFileClient,
+) -> None:
+    s: SparkSession = spark.spark_session
+    country_code = config.country_code
+    dataset_type = "coverage"
+    staging_tier_schema_name = construct_schema_name_for_tier(
+        f"school_{dataset_type}", DataTier.STAGING
+    )
+    staging_table_name = construct_full_table_name(
+        staging_tier_schema_name, country_code
+    )
+
+    # Check if staging table exists
+    staging_table_exists = check_table_exists(
+        spark=s,
+        schema_name=config.metastore_schema,
+        table_name=country_code.lower(),
+        data_tier=DataTier.STAGING,
+    )
+    context.log.info(f"{staging_table_exists=}")
+
+    if not staging_table_exists:
+        context.log.info(
+            f"Staging table {staging_table_name} does not exist. Skipping reset."
+        )
+        return None
+
+    staging_table_path = config.destination_filepath
+    silver_tier_schema_name = construct_schema_name_for_tier(
+        f"school_{dataset_type}", DataTier.SILVER
+    )
+    silver_table_name = construct_full_table_name(silver_tier_schema_name, country_code)
+
+    s.sql(f"DROP TABLE IF EXISTS {staging_table_name}")
+
+    try:
+        adls_file_client.delete(staging_table_path, is_directory=True)
+    except ResourceNotFoundError as e:
+        context.log.warning(e)
+
+    schema_columns = get_schema_columns(s, config.metastore_schema)
+    silver = DeltaTable.forName(s, silver_table_name).alias("silver").toDF()
+    create_schema(s, staging_tier_schema_name)
+    create_delta_table(
+        s,
+        staging_tier_schema_name,
+        country_code,
+        schema_columns,
+        context,
+        if_not_exists=True,
+    )
+    silver.write.format("delta").mode("append").saveAsTable(staging_table_name)
+
+    formatted_dataset = f"School {dataset_type.capitalize()}"
+    with get_db_context() as db:
+        with db.begin():
+            db.execute(
+                update(ApprovalRequest)
+                .where(
+                    (ApprovalRequest.country == country_code)
+                    & (ApprovalRequest.dataset == formatted_dataset)
+                )
+                .values(
+                    {
+                        ApprovalRequest.is_merge_processing: False,
+                        ApprovalRequest.enabled: False,
+                    }
+                )
+            )
 
 
 @asset

--- a/dagster/src/sensors/adhoc.py
+++ b/dagster/src/sensors/adhoc.py
@@ -173,6 +173,18 @@ def school_master__gold_csv_to_deltatable_sensor(
                 metastore_schema=reference_metastore_schema,
                 tier=DataTier.GOLD,
             ),
+            "adhoc__reset_geolocation_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_staging.db/{country_code.lower()}",
+                metastore_schema="school_geolocation",
+                tier=DataTier.STAGING,
+            ),
+            "adhoc__reset_coverage_staging_table": OpDestinationMapping(
+                source_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_staging.db/{country_code.lower()}",
+                metastore_schema="school_coverage",
+                tier=DataTier.STAGING,
+            ),
             "adhoc__broadcast_master_release_notes": OpDestinationMapping(
                 source_filepath=f"{constants.gold_folder}/dq-results/school-master/passed/{stem}.csv",
                 destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/{master_metastore_schema}.db/{country_code}",


### PR DESCRIPTION
## Summary

This PR fixes the issue detailed below:

> In prod an issue was raised wherein the staging table seems to be in a hanging state causing miscounts in the reported number of rows. This can be explained by the following:
> 
> `reset_staging_table` materializes in the post-approval run
> 
> reset drops the staging table, recreates it and copies the contents of silver
> 
> after this post approval run in staging, silver and master contained 152,214 rows
> 
> due to issues caused by the connectivity columns, a backend update was performed rolling back master and silver to 148,323 rows
> 
> at this point `geolocation_staging` still has 152,214 rows
> 
> when the ingestion was retried the system detected the difference between silver and staging and that appeared in the summary
> 
> 
> 
> Changes are required so that `reset_staging_table` happens in bulk ingestions.

## How to test

1. Access giga sync and upload a school geolocation or coverage file.
2. Perform a backend update
3. Via Superset, check the row counts for staging and silver
4. Expect staging table has the same row count as silver
5. Retry the ingestion from step 1
6. Expect row counts to match
 
