### PR TITLE
fix: handle download speed being nan in connectivity logic

### DIFF
--- a/dagster/src/sensors/qos_availability.py
+++ b/dagster/src/sensors/qos_availability.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from dagster import RunConfig, RunRequest, SensorEvaluationContext, SkipReason, sensor
 from src.constants import DataTier, constants
 from src.jobs.qos import qos_availability_create_silver_job
@@ -11,6 +12,7 @@ DATASET_TYPE = "availability"
 DOMAIN = "qos"
 DOMAIN_DATASET_TYPE = f"{DOMAIN}-{DATASET_TYPE}"
 METASTORE_SCHEMA = f"{DOMAIN}_{DATASET_TYPE}"
+
 
 @sensor(
     job=qos_availability_create_silver_job,

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -722,6 +722,7 @@ def merge_connectivity_to_master(
                     & (
                         (f.col("download_speed_govt") != 0)
                         | f.col("download_speed_govt").isNull()
+                        | f.isnan(f.col("download_speed_govt"))
                     )
                 )
                 | (f.col("download_speed_govt") > 0),


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

What does this PR do

Because download_speed_govt is a numeric field, it may be `nan` instead of `NULL` in some cases. This updates the `connectivity` field logic to cater for this instead of only handling it when it is `NULL`

## How to test
Upload a file with download_speed_govt empty and set values for connectivity_govt and check if the results are what is expected
