### PR TITLE
feat: enable changing connectivity to unknown

### DIFF
--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -760,6 +760,7 @@ def merge_connectivity_to_master(
             "connectivity",
             f.when(f.lower(f.col("connectivity_govt")) == "yes", "Yes")
             .when(f.lower(f.col("connectivity_govt")) == "no", "No")
+            .when(f.lower(f.col("connectivity_govt")) == "unknown", "Unknown")
             .otherwise(f.lit(None).cast(StringType())),
         )
     elif "download_speed_govt" in uploaded_columns:


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary

What does this PR do

## How to test

Upload a file where `connectivity_govt` is `Unkown` for some schools. `connectivity` should be hange to `Unknown` for those schools
