### PR TITLE
[Giga-032]: Delete assertions

### DIFF
--- a/dagster/src/assets/datahub_assets/datahub_assets.py
+++ b/dagster/src/assets/datahub_assets/datahub_assets.py
@@ -243,6 +243,10 @@ class ListAssertionsConfig(Config):
 
     batch_size: int = Field(100, description="Assertions to delete at a time")
     max_iterations: int = Field(10, description="Number of batches to delete")
+    num_workers: int = Field(
+        5,
+        description="Number of worker threads to use for parallel processing",
+    )
 
 
 @asset
@@ -264,7 +268,9 @@ def datahub__purge_assertions(
             break
 
         # Create parallel batches
-        batches = create_parallel_batches(all_assertion_urns, num_parallel=5)
+        batches = create_parallel_batches(
+            all_assertion_urns, num_parallel=config.num_workers
+        )
 
         logger.info(
             f"Iteration {iteration + 1}: Processing {len(all_assertion_urns)} assertions in {len(batches)} parallel batches"
@@ -312,7 +318,9 @@ class ListPlatformEntitiesConfig(Config):
 def datahub__list_entity_count(
     context: OpExecutionContext,
 ) -> None:
-    total_assertions = get_entity_count_safe("assertion", batch_size=150)
+    total_assertions = get_entity_count_safe(
+        "assertion", batch_size=150
+    )  # fails if more than 200 batches
     context.log.info(f"Total assertions in DataHub: {total_assertions}")
 
 

--- a/dagster/src/assets/datahub_assets/datahub_assets.py
+++ b/dagster/src/assets/datahub_assets/datahub_assets.py
@@ -15,6 +15,7 @@ from src.utils.datahub.batch_processing import (
 from src.utils.datahub.create_domains import create_domains
 from src.utils.datahub.create_tags import create_tags
 from src.utils.datahub.datahub_ingest_nb_metadata import NotebookIngestionAction
+from src.utils.datahub.entity import get_entity_count_safe
 from src.utils.datahub.graphql import datahub_graph_client
 from src.utils.datahub.ingest_azure_ad import (
     ingest_azure_ad_to_datahub_pipeline,
@@ -304,6 +305,15 @@ class ListPlatformEntitiesConfig(Config):
         [],
         description="List of specific URNs to filter entities by. If empty, all entities for the platform will be considered for deletion.",
     )
+
+
+@asset
+@capture_op_exceptions
+def datahub__list_entity_count(
+    context: OpExecutionContext,
+) -> None:
+    total_assertions = get_entity_count_safe("assertion", batch_size=150)
+    context.log.info(f"Total assertions in DataHub: {total_assertions}")
 
 
 @asset

--- a/dagster/src/jobs/datahub.py
+++ b/dagster/src/jobs/datahub.py
@@ -93,11 +93,9 @@ datahub__add_business_glossary_job = define_asset_job(
 
 datahub__purge_assertions_job = define_asset_job(
     name="datahub__purge_assertions_job",
-    description="Soft deletes all assertions by default; can be changed to hard delete via Launchpad.",
+    description="Deletes all assertions and references to them",
     selection=[
-        "datahub__list_assertions",
-        "datahub__soft_delete_assertions",
-        "datahub__hard_delete_assertions",
+        "datahub__purge_assertions",
     ],
     tags={"dagster/max_runtime": settings.DEFAULT_MAX_RUNTIME},
 )

--- a/dagster/src/utils/datahub/batch_processing.py
+++ b/dagster/src/utils/datahub/batch_processing.py
@@ -1,0 +1,116 @@
+"""Utility functions for batch processing DataHub operations."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from loguru import logger
+
+from dagster import OpExecutionContext
+from src.utils.datahub.entity import delete_entity_with_references
+
+
+def delete_assertion_batch(
+    context: OpExecutionContext, batch_info: tuple
+) -> tuple[int, int]:
+    """Delete a batch of assertions and return counts.
+
+    Args:
+        context: Dagster execution context
+        batch_info: Tuple of (batch_start_index, list_of_assertion_urns)
+
+    Returns:
+        Tuple of (batch_deleted_count, batch_references_deleted_count)
+    """
+    batch_start, batch_urns = batch_info
+    batch_deleted = 0
+    batch_refs_deleted = 0
+
+    for i, assertion_urn in enumerate(batch_urns):
+        try:
+            ref_count = delete_entity_with_references(context, assertion_urn)
+            batch_refs_deleted += ref_count
+            batch_deleted += 1
+            logger.info(
+                f"Batch {batch_start}-{batch_start + len(batch_urns) - 1}: "
+                f"Deleted {i + 1}/{len(batch_urns)}: {assertion_urn}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to delete {assertion_urn}: {e}")
+
+    return batch_deleted, batch_refs_deleted
+
+
+def create_parallel_batches(items: list, num_parallel: int = 5) -> list[tuple]:
+    """Split a list of items into parallel batches.
+
+    Args:
+        items: List of items to split into batches
+        num_parallel: Number of parallel batches to create
+
+    Returns:
+        List of tuples (start_index, batch_items)
+    """
+    if not items:
+        return []
+
+    batch_size = len(items) // num_parallel
+    if batch_size == 0:
+        batch_size = 1
+        num_parallel = len(items)
+
+    batches = []
+    for i in range(num_parallel):
+        start_idx = i * batch_size
+        end_idx = start_idx + batch_size if i < num_parallel - 1 else len(items)
+        if start_idx < len(items):
+            batch_items = items[start_idx:end_idx]
+            batches.append((start_idx, batch_items))
+
+    return batches
+
+
+def process_batches_in_parallel(
+    context: OpExecutionContext,
+    batches: list[tuple],
+    batch_processor_func,
+    max_workers: int = None,
+) -> tuple[int, int]:
+    """Process multiple batches in parallel using ThreadPoolExecutor.
+
+    Args:
+        context: Dagster execution context
+        batches: List of batch tuples to process
+        batch_processor_func: Function to process each batch
+        max_workers: Maximum number of worker threads
+
+    Returns:
+        Tuple of (total_items_processed, total_references_processed)
+    """
+    total_processed = 0
+    total_references = 0
+
+    if not batches:
+        return total_processed, total_references
+
+    if max_workers is None:
+        max_workers = len(batches)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_batch = {
+            executor.submit(batch_processor_func, context, batch): batch
+            for batch in batches
+        }
+
+        for future in as_completed(future_to_batch):
+            batch_info = future_to_batch[future]
+            try:
+                batch_processed, batch_refs = future.result()
+                total_processed += batch_processed
+                total_references += batch_refs
+                logger.info(
+                    f"Completed batch {batch_info[0]}: "
+                    f"processed {batch_processed} items, {batch_refs} references"
+                )
+            except Exception as e:
+                logger.error(f"Batch {batch_info[0]} failed: {e}")
+
+    return total_processed, total_references

--- a/dagster/src/utils/datahub/entity.py
+++ b/dagster/src/utils/datahub/entity.py
@@ -1,0 +1,20 @@
+from loguru import logger
+
+from dagster import OpExecutionContext
+from src.utils.datahub.graphql import datahub_graph_client
+
+
+def delete_entity_with_references(context: OpExecutionContext, urn: str) -> int:
+    """Delete an entity and its references, returning the number of references deleted."""
+    reference_count, _ = datahub_graph_client.delete_references_to_urn(
+        urn=urn,
+        dry_run=False,
+    )
+
+    if reference_count > 0:
+        context.log.info(f"Deleted {reference_count} references to {urn}")
+
+    datahub_graph_client.hard_delete_entity(urn=urn)
+    logger.info(f"Hard deleted entity: {urn}")
+
+    return reference_count

--- a/dagster/src/utils/datahub/entity.py
+++ b/dagster/src/utils/datahub/entity.py
@@ -18,3 +18,62 @@ def delete_entity_with_references(context: OpExecutionContext, urn: str) -> int:
     logger.info(f"Hard deleted entity: {urn}")
 
     return reference_count
+
+
+def get_entity_count_safe(entity_type: str = "assertion", batch_size: int = 100):
+    """
+    Get the total count of entities using safe pagination to avoid timeouts.
+
+    Args:
+        entity_type: Type of entity to count (e.g., "assertion", "dataset")
+        batch_size: Small batch size to avoid timeouts (default: 100)
+
+    Returns:
+        Total count of entities
+    """
+    total_count = 0
+    start = 0
+
+    print(f"🔍 Counting {entity_type} entities with batch size {batch_size}...")
+
+    while True:
+        try:
+            print(f"  📊 Fetching batch starting at {start}")
+
+            # Get entities for this batch with small count to avoid timeout
+            entities = datahub_graph_client.list_all_entity_urns(
+                entity_type=entity_type,
+                start=start,
+                count=batch_size,
+            )
+
+            batch_count = len(entities)
+            total_count += batch_count
+
+            print(f"  ✅ Found {batch_count} entities (total so far: {total_count})")
+
+            # If we got fewer entities than requested, we've reached the end
+            if batch_count < batch_size:
+                print(f"🎯 Reached end of {entity_type} entities")
+                break
+
+            start += batch_size
+
+            # Safety check to prevent infinite loops
+            if start > 500000:  # Reasonable safety limit
+                print("⚠️ Reached safety limit, stopping count")
+                break
+
+        except Exception as e:
+            print(f"❌ Error fetching batch at start={start}: {e}")
+            # Try with even smaller batch size
+            if batch_size > 10:
+                batch_size = batch_size // 2
+                print(f"🔄 Retrying with smaller batch size: {batch_size}")
+                continue
+            else:
+                print("💥 Failed even with smallest batch size")
+                break
+
+    print(f"🎯 Final {entity_type} count: {total_count}")
+    return total_count


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary

What does this PR do

- Update delete assertion logic to include headless assertions
- Hard deletes assertions by default
- Add utils to delete assertions `entities` in parellel
- Add utils to list the total number of `assertion` entities

## How to test

Note: Ideally run these locally instead with your own datahub access token as our deployed envs currently do not retain stdout and stderr logs

1. Run `datahub__purge_assertions job`. Change `batch_size` and `iterations` to modify the total number of assertions to delete
2. Run `datahub__list_entity_count` asset to confirm that the numbre of assertion entities dropped


## Link to Jira/Asana/Airtable task (if applicable)

https://app.clickup.com/t/25789471/TECH-6059