### PR TITLE
feat: use nocodb for categorical column key value mapping

### DIFF
--- a/azure/templates/create-config.yaml
+++ b/azure/templates/create-config.yaml
@@ -74,6 +74,7 @@ jobs:
                     PROCO_DB_CONNECTION_STRING: "$(procoDbConnectionString)"
                     NOCODB_BASE_URL: "$(nocoDBURL)"
                     NOCODB_TOKEN: "$(nocoDBToken)"
+                    NOCODB_NAME_MAPPINGS_TABLE_ID: "$(nocoDBNameMappingsTableId)"
                     SPARK_DRIVER_CORES: "$(sparkDriverCores)"
                     SPARK_DRIVER_MEMORY_MB: "$(sparkDriverMemoryMB)"
                     GITHUB_ACCESS_TOKEN: "$(githubAccessToken)"

--- a/azure/templates/create-config.yaml
+++ b/azure/templates/create-config.yaml
@@ -72,6 +72,8 @@ jobs:
                     GIGAMETER_DB_CONNECTION_STRING: "$(gigameterDbConnectionString)"
                     MLAB_DB_CONNECTION_STRING: "$(mlabDbConnectionString)"
                     PROCO_DB_CONNECTION_STRING: "$(procoDbConnectionString)"
+                    NOCODB_BASE_URL: "$(nocoDBURL)"
+                    NOCODB_TOKEN: "$(nocoDBToken)"
                     SPARK_DRIVER_CORES: "$(sparkDriverCores)"
                     SPARK_DRIVER_MEMORY_MB: "$(sparkDriverMemoryMB)"
                     GITHUB_ACCESS_TOKEN: "$(githubAccessToken)"

--- a/azure/templates/variables.yaml
+++ b/azure/templates/variables.yaml
@@ -37,6 +37,7 @@ variables:
   procoDbConnectionString: $(PROCO_DB_CONNECTION_STRING)
   nocoDBURL: $(NOCODB_BASE_URL)
   nocoDBToken: $(NOCODB_TOKEN)
+  nocoDBNameMappingsTableId: $(NOCODB_NAME_MAPPINGS_TABLE_ID)
   deployEnv: $(DEPLOY_ENV)
   sentryDsn: $(SENTRY_DSN)
   ingressHost: $(INGRESS_HOST)

--- a/azure/templates/variables.yaml
+++ b/azure/templates/variables.yaml
@@ -35,6 +35,8 @@ variables:
   gigameterDbConnectionString: $(GIGAMETER_DB_CONNECTION_STRING)
   mlabDbConnectionString: $(MLAB_DB_CONNECTION_STRING)
   procoDbConnectionString: $(PROCO_DB_CONNECTION_STRING)
+  nocoDBURL: $(NOCODB_BASE_URL)
+  nocoDBToken: $(NOCODB_TOKEN)
   deployEnv: $(DEPLOY_ENV)
   sentryDsn: $(SENTRY_DSN)
   ingressHost: $(INGRESS_HOST)

--- a/dagster/src/settings.py
+++ b/dagster/src/settings.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     GIGAMETER_DB_CONNECTION_STRING: str = ""
     NOCODB_BASE_URL: str = ""
     NOCODB_TOKEN: str = ""
+    NOCODB_NAME_MAPPINGS_TABLE_ID: str = ""
 
     # Derived settings
     @property

--- a/dagster/src/settings.py
+++ b/dagster/src/settings.py
@@ -61,6 +61,8 @@ class Settings(BaseSettings):
     PROCO_DB_CONNECTION_STRING: str = ""
     GIGAMAPS_DB_CONNECTION_STRING: str = ""
     GIGAMETER_DB_CONNECTION_STRING: str = ""
+    NOCODB_BASE_URL: str = ""
+    NOCODB_TOKEN: str = ""
 
     # Derived settings
     @property

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -24,6 +24,7 @@ from dagster import OpExecutionContext
 from src.constants import UploadMode
 from src.settings import settings
 from src.spark.udf_dependencies import get_point
+from src.utils.get_nocodb_data import get_nocodb_table_as_key_value_mapping
 from src.utils.logger import get_context_with_fallback_logger
 
 ACCOUNT_URL = "https://saunigiga.blob.core.windows.net/"
@@ -90,20 +91,11 @@ def create_school_id_giga(df: sql.DataFrame) -> sql.DataFrame:
 def create_education_level(
     df: sql.DataFrame, mode: str, uploaded_columns: list[str]
 ) -> sql.DataFrame:
-    education_level_govt_mapping = {
-        "Other": "Unknown",
-        "Unknown": "Unknown",
-        "Pre-Primary, Primary and Secondary": "Pre-Primary, Primary and Secondary",
-        "Primary, Secondary and Post-Secondary": "Primary, Secondary and Post-Secondary",
-        "Basic": "Primary",
-        "Basic And Secondary": "Primary and Secondary",
-        "Pre-Primary": "Pre-Primary",
-        "Primary": "Primary",
-        "Secondary": "Secondary",
-        "Post-Secondary": "Post-Secondary",
-        "Pre-Primary And Primary": "Pre-Primary and Primary",
-        "Primary And Secondary": "Primary and Secondary",
-    }
+    education_level_nocodb_table_id = ""
+    education_level_nocodb_view_id = ""
+    education_level_govt_mapping = get_nocodb_table_as_key_value_mapping(
+        table_id=education_level_nocodb_table_id, view_id=education_level_nocodb_view_id
+    )
 
     education_level_govt_mapping = {
         key.lower(): value for key, value in education_level_govt_mapping.items()
@@ -487,6 +479,7 @@ def add_admin_columns(  # noqa: C901
         for _, row in broadcasted_admin_boundaries.value.iterrows():
             if row.geometry.contains(point):
                 return row.get("name")
+        return None
         return None
 
     get_admin_native_udf = f.udf(get_admin_native, StringType())

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -25,7 +25,10 @@ from src.constants import UploadMode
 from src.settings import settings
 from src.spark.udf_dependencies import get_point
 from src.utils.logger import get_context_with_fallback_logger
-from src.utils.nocodb.get_nocodb_data import get_nocodb_table_as_key_value_mapping
+from src.utils.nocodb.get_nocodb_data import (
+    get_nocodb_table_as_key_value_mapping,
+    get_nocodb_table_id_from_name,
+)
 
 ACCOUNT_URL = "https://saunigiga.blob.core.windows.net/"
 azure_sas_token = settings.AZURE_SAS_TOKEN
@@ -91,10 +94,11 @@ def create_school_id_giga(df: sql.DataFrame) -> sql.DataFrame:
 def create_education_level(
     df: sql.DataFrame, mode: str, uploaded_columns: list[str]
 ) -> sql.DataFrame:
-    education_level_nocodb_table_id = ""
-    education_level_nocodb_view_id = ""
+    education_level_nocodb_table_id = get_nocodb_table_id_from_name(
+        table_name="EducationLevelMapping"
+    )
     education_level_govt_mapping = get_nocodb_table_as_key_value_mapping(
-        table_id=education_level_nocodb_table_id, view_id=education_level_nocodb_view_id
+        table_id=education_level_nocodb_table_id
     )
 
     education_level_govt_mapping = {

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -24,8 +24,8 @@ from dagster import OpExecutionContext
 from src.constants import UploadMode
 from src.settings import settings
 from src.spark.udf_dependencies import get_point
-from src.utils.get_nocodb_data import get_nocodb_table_as_key_value_mapping
 from src.utils.logger import get_context_with_fallback_logger
+from src.utils.nocodb.get_nocodb_data import get_nocodb_table_as_key_value_mapping
 
 ACCOUNT_URL = "https://saunigiga.blob.core.windows.net/"
 azure_sas_token = settings.AZURE_SAS_TOKEN

--- a/dagster/src/utils/nocodb/get_nocodb_data.py
+++ b/dagster/src/utils/nocodb/get_nocodb_data.py
@@ -75,7 +75,7 @@ def get_nocodb_table_as_pandas_dataframe(table_id, where=None, fields=None):
         (i.e., df.iloc[:, 3:]).
     """
 
-    rows_list = get_nocodb_table_rows(table_id)
+    rows_list = get_nocodb_table_rows(table_id, where=where, fields=fields)
     if not rows_list:
         return pd.DataFrame()
 
@@ -139,4 +139,4 @@ def get_nocodb_table_id_from_name(table_name):
     if nocodb_response:
         return nocodb_response[0]["table_id"]
     else:
-        raise ValueError(f"Issue retrieiving the table_id for table {table_name}")
+        raise ValueError(f"Unable to retrieve the table_id for table {table_name}")

--- a/dagster/src/utils/nocodb/get_nocodb_data.py
+++ b/dagster/src/utils/nocodb/get_nocodb_data.py
@@ -1,0 +1,122 @@
+import pandas as pd
+import requests
+
+from src.settings import settings
+
+
+def get_nocodb_table_rows(view_id, table_id, offset=0, limit=100, where=""):
+    """
+    Retrieve rows from a specified NoCoDB table and returns them as a list of dictionaries
+
+    Args:
+        view_id (str): The ID of the NocoDB view to query.
+        table_id (str): The ID of the NocoDB table to query.
+        offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
+        limit (int, optional): Maximum number of rows to return. Defaults to 500.
+        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
+
+    Returns:
+        list[dict]: A list of dictionaries representing the rows in the table.
+
+    """
+
+    table_url = f"{settings.NOCODB_BASE_URL}/api/v2/tables/{table_id}/records"
+    headers = {"xc-token": settings.NOCODB_TOKEN}
+
+    offset = offset or 0
+    all_rows = []
+    is_last_page = False
+
+    # loop through and get all the data in the table
+    while not is_last_page:
+        # set the parameters to query the current page of data
+        params = {"offset": offset, "limit": limit, "where": where, "viewID": view_id}
+
+        # fetch the data from the api
+        response = requests.get(table_url, params=params, headers=headers)
+        response_json = response.json()
+        rows = response_json.get("list", [])
+        all_rows.extend(rows)
+
+        # get the page info to determine how to continue
+        page_info = response_json.get("pageInfo")
+        page_size = page_info.get("pageSize", 0)
+        offset += page_size
+        is_last_page = page_info.get("isLastPage", False)
+
+    return
+
+
+def get_nocodb_table_as_pandas_dataframe(
+    view_id, table_id, offset=0, limit=500, where=""
+):
+    """
+    Retrieve data from a NoCoDB table and convert it to a pandas DataFrame.
+
+    Args:
+        view_id (str): The ID of the NoCoDB view to query.
+        table_id (str): The ID of the NoCoDB table to query.
+        offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
+        limit (int, optional): Maximum number of rows to return. Defaults to 500.
+        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
+
+    Returns:
+        pandas.DataFrame: A DataFrame containing the table data, with empty rows removed.
+            Only rows that have at least one non-null value in columns after the third column are included.
+
+    Notes:
+        The function removes any rows that have all NULL values in columns after the third column
+        (i.e., df.iloc[:, 3:]).
+    """
+
+    rows_list = get_nocodb_table_rows(
+        view_id, table_id, offset=offset, limit=limit, where=where
+    )
+    df = pd.DataFrame(rows_list)
+    df = df[df.iloc[:, 3:].notna().any(axis="columns")]
+    return df
+
+
+def get_nocodb_table_as_key_value_mapping(
+    view_id, table_id, key_column=None, value_column=None, offset=0, limit=500, where=""
+):
+    """
+    Convert a NoCoDB table into a mapping of key-value pairs. If columns are not explicitly provided,
+    it defaults to using the 4th and 5th columns (index-based) from the fetched data rows.
+    Only non-empty key-value pairs are included in the resulting mapping.
+
+    Args:
+        view_id (str): The ID of the NoCoDB view to query.
+        table_id (str): The ID of the NoCoDB table to query.
+        key_column (str, optional): Name of the column to use as the key. Defaults to None.
+        value_column (str, optional): Name of the column to use as the value. Defaults to None.
+        offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
+        limit (int, optional): Maximum number of rows to return. Defaults to 500.
+        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
+
+    Returns:
+    dict: key-value mapping derived from the specified table and columns.
+
+    Raises:
+    TypeError
+        Raised when only one of `key_column` or `value_column` is provided instead of both or neither.
+    """
+    if any((key_column, value_column)) and not all((key_column, value_column)):
+        raise TypeError(
+            "Either both key_column and value_column must be provided or neither"
+        )
+    rows_list = get_nocodb_table_rows(
+        view_id, table_id, offset=offset, limit=limit, where=where
+    )
+
+    if not (key_column and value_column):
+        columns = list(rows_list[0].keys())
+        key_column, value_column = columns[3], columns[4]
+
+    mapping_dict = {
+        item[key_column]: item[value_column]
+        for item in rows_list
+        if (item[key_column] or item[value_column])
+    }
+
+    return mapping_dict

--- a/dagster/src/utils/nocodb/get_nocodb_data.py
+++ b/dagster/src/utils/nocodb/get_nocodb_data.py
@@ -4,7 +4,7 @@ import requests
 from src.settings import settings
 
 
-def get_nocodb_table_rows(table_id, offset=0, limit=100):
+def get_nocodb_table_rows(table_id, offset=0, limit=100, where=None, fields=None):
     """
     Retrieve rows from a specified NoCoDB table and returns them as a list of dictionaries
 
@@ -12,6 +12,8 @@ def get_nocodb_table_rows(table_id, offset=0, limit=100):
         table_id (str): The ID of the NocoDB table to query.
         offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
         limit (int, optional): Maximum number of rows to return. Defaults to 500.
+        where (str, optional): A query string for filtering rows based on conditions.
+        fields (str, optional): A string specifying the fields to include in the result.
 
     Returns:
         list[dict]: A list of dictionaries representing the rows in the table.
@@ -25,10 +27,20 @@ def get_nocodb_table_rows(table_id, offset=0, limit=100):
     all_rows = []
     is_last_page = False
 
+    if where and fields:
+        params_base = {where: where, fields: fields}
+    elif where:
+        params_base = {where: where}
+    elif fields:
+        params_base = {fields: fields}
+    else:
+        params_base = {}
+
     # loop through and get all the data in the table
     while not is_last_page:
         # set the parameters to query the current page of data
         params = {"offset": offset, "limit": limit}
+        params = {**params_base, **params}
 
         # fetch the data from the api
         response = requests.get(table_url, params=params, headers=headers)
@@ -42,15 +54,17 @@ def get_nocodb_table_rows(table_id, offset=0, limit=100):
         offset += page_size
         is_last_page = page_info.get("isLastPage", False)
 
-    return
+    return all_rows
 
 
-def get_nocodb_table_as_pandas_dataframe(table_id):
+def get_nocodb_table_as_pandas_dataframe(table_id, where=None, fields=None):
     """
     Retrieve data from a NoCoDB table and convert it to a pandas DataFrame.
 
     Args:
         table_id (str): The ID of the NoCoDB table to query.
+        where (str, optional): A query string for filtering rows based on conditions.
+        fields (str, optional): A string specifying the fields to include in the result.
 
     Returns:
         pandas.DataFrame: A DataFrame containing the table data, with empty rows removed.
@@ -62,12 +76,17 @@ def get_nocodb_table_as_pandas_dataframe(table_id):
     """
 
     rows_list = get_nocodb_table_rows(table_id)
+    if not rows_list:
+        return pd.DataFrame()
+
     df = pd.DataFrame(rows_list)
     df = df[df.iloc[:, 3:].notna().any(axis="columns")]
     return df
 
 
-def get_nocodb_table_as_key_value_mapping(table_id, key_column=None, value_column=None):
+def get_nocodb_table_as_key_value_mapping(
+    table_id, key_column=None, value_column=None, where=None
+):
     """
     Convert a NoCoDB table into a mapping of key-value pairs. If columns are not explicitly provided,
     it defaults to using the 4th and 5th columns (index-based) from the fetched data rows.
@@ -77,6 +96,8 @@ def get_nocodb_table_as_key_value_mapping(table_id, key_column=None, value_colum
         table_id (str): The ID of the NoCoDB table to query.
         key_column (str, optional): Name of the column to use as the key. Defaults to None.
         value_column (str, optional): Name of the column to use as the value. Defaults to None.
+        where (str, optional): A query string for filtering rows based on conditions.
+        fields (str, optional): A string specifying the fields to include in the result.
 
     Returns:
     dict: key-value mapping derived from the specified table and columns.
@@ -89,7 +110,13 @@ def get_nocodb_table_as_key_value_mapping(table_id, key_column=None, value_colum
         raise TypeError(
             "Either both key_column and value_column must be provided or neither"
         )
-    rows_list = get_nocodb_table_rows(table_id)
+    elif key_column and value_column:
+        fields = f"{key_column},{value_column}"
+    else:
+        fields = None
+    rows_list = get_nocodb_table_rows(table_id, where=where, fields=fields)
+    if not rows_list:
+        return {}
 
     if not (key_column and value_column):
         columns = list(rows_list[0].keys())
@@ -102,3 +129,14 @@ def get_nocodb_table_as_key_value_mapping(table_id, key_column=None, value_colum
     }
 
     return mapping_dict
+
+
+def get_nocodb_table_id_from_name(table_name):
+    table_name_mappings_id = settings.NOCODB_NAME_MAPPINGS_TABLE_ID
+    nocodb_response = get_nocodb_table_rows(
+        table_name_mappings_id, where=f"(table_name,eq,{table_name})", fields="table_id"
+    )
+    if nocodb_response:
+        return nocodb_response[0]["table_id"]
+    else:
+        raise ValueError(f"Issue retrieiving the table_id for table {table_name}")

--- a/dagster/src/utils/nocodb/get_nocodb_data.py
+++ b/dagster/src/utils/nocodb/get_nocodb_data.py
@@ -4,16 +4,14 @@ import requests
 from src.settings import settings
 
 
-def get_nocodb_table_rows(view_id, table_id, offset=0, limit=100, where=""):
+def get_nocodb_table_rows(table_id, offset=0, limit=100):
     """
     Retrieve rows from a specified NoCoDB table and returns them as a list of dictionaries
 
     Args:
-        view_id (str): The ID of the NocoDB view to query.
         table_id (str): The ID of the NocoDB table to query.
         offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
         limit (int, optional): Maximum number of rows to return. Defaults to 500.
-        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
 
     Returns:
         list[dict]: A list of dictionaries representing the rows in the table.
@@ -30,7 +28,7 @@ def get_nocodb_table_rows(view_id, table_id, offset=0, limit=100, where=""):
     # loop through and get all the data in the table
     while not is_last_page:
         # set the parameters to query the current page of data
-        params = {"offset": offset, "limit": limit, "where": where, "viewID": view_id}
+        params = {"offset": offset, "limit": limit}
 
         # fetch the data from the api
         response = requests.get(table_url, params=params, headers=headers)
@@ -47,18 +45,12 @@ def get_nocodb_table_rows(view_id, table_id, offset=0, limit=100, where=""):
     return
 
 
-def get_nocodb_table_as_pandas_dataframe(
-    view_id, table_id, offset=0, limit=500, where=""
-):
+def get_nocodb_table_as_pandas_dataframe(table_id):
     """
     Retrieve data from a NoCoDB table and convert it to a pandas DataFrame.
 
     Args:
-        view_id (str): The ID of the NoCoDB view to query.
         table_id (str): The ID of the NoCoDB table to query.
-        offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
-        limit (int, optional): Maximum number of rows to return. Defaults to 500.
-        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
 
     Returns:
         pandas.DataFrame: A DataFrame containing the table data, with empty rows removed.
@@ -69,30 +61,22 @@ def get_nocodb_table_as_pandas_dataframe(
         (i.e., df.iloc[:, 3:]).
     """
 
-    rows_list = get_nocodb_table_rows(
-        view_id, table_id, offset=offset, limit=limit, where=where
-    )
+    rows_list = get_nocodb_table_rows(table_id)
     df = pd.DataFrame(rows_list)
     df = df[df.iloc[:, 3:].notna().any(axis="columns")]
     return df
 
 
-def get_nocodb_table_as_key_value_mapping(
-    view_id, table_id, key_column=None, value_column=None, offset=0, limit=500, where=""
-):
+def get_nocodb_table_as_key_value_mapping(table_id, key_column=None, value_column=None):
     """
     Convert a NoCoDB table into a mapping of key-value pairs. If columns are not explicitly provided,
     it defaults to using the 4th and 5th columns (index-based) from the fetched data rows.
     Only non-empty key-value pairs are included in the resulting mapping.
 
     Args:
-        view_id (str): The ID of the NoCoDB view to query.
         table_id (str): The ID of the NoCoDB table to query.
         key_column (str, optional): Name of the column to use as the key. Defaults to None.
         value_column (str, optional): Name of the column to use as the value. Defaults to None.
-        offset (int, optional): Number of rows to skip before starting to return rows. Defaults to 0.
-        limit (int, optional): Maximum number of rows to return. Defaults to 500.
-        where (str, optional): SQL-like WHERE clause to filter the results. Defaults to empty string.
 
     Returns:
     dict: key-value mapping derived from the specified table and columns.
@@ -105,9 +89,7 @@ def get_nocodb_table_as_key_value_mapping(
         raise TypeError(
             "Either both key_column and value_column must be provided or neither"
         )
-    rows_list = get_nocodb_table_rows(
-        view_id, table_id, offset=offset, limit=limit, where=where
-    )
+    rows_list = get_nocodb_table_rows(table_id)
 
     if not (key_column and value_column):
         columns = list(rows_list[0].keys())


### PR DESCRIPTION
## What type of PR is this?

- `feat`: Commits that add a new feature

## Summary

What does this PR do

1. Adds nocodb integration to the Dagster pipelines, introducing reusable functions that can be used to fetch data from nocodb to use within the pipeline
2. Also updates the education level mapping so that it is pulled from nocodb
