### PR TITLE
[GIGA-032] remove custom spark related assertions emits

### DIFF
--- a/dagster/src/assets/adhoc/master_csv_to_gold.py
+++ b/dagster/src/assets/adhoc/master_csv_to_gold.py
@@ -32,9 +32,6 @@ from src.spark.transform_functions import (
     add_missing_columns,
 )
 from src.utils.adls import ADLSFileClient
-from src.utils.datahub.create_validation_tab import (
-    datahub_emit_assertions_with_exception_catcher,
-)
 from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
@@ -648,9 +645,7 @@ def adhoc__publish_master_to_gold(
         spark=spark,
         schema_reference=schema_reference,
     )
-    datahub_emit_assertions_with_exception_catcher(
-        context=context, dq_summary_statistics=adhoc__master_dq_checks_summary
-    )
+
     upstream_filepaths = [
         f"{settings.SPARK_WAREHOUSE_PATH}/school_geolocation_silver.db/{config.country_code.lower()}",
         f"{settings.SPARK_WAREHOUSE_PATH}/school_coverage_silver.db/{config.country_code.lower()}",

--- a/dagster/src/assets/adhoc/master_dq_checks.py
+++ b/dagster/src/assets/adhoc/master_dq_checks.py
@@ -6,12 +6,7 @@ from pyspark.sql import (
     functions as f,
 )
 from src.data_quality_checks.utils import (
-    aggregate_report_json,
-    aggregate_report_spark_df,
     row_level_checks,
-)
-from src.utils.datahub.create_validation_tab import (
-    datahub_emit_assertions_with_exception_catcher,
 )
 from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
@@ -47,11 +42,6 @@ def adhoc__standalone_master_data_quality_checks(
             context=context,
         ),
         "Row level checks completed",
-    )
-    dq_summary = aggregate_report_json(
-        df_aggregated=aggregate_report_spark_df(s, dq_checked),
-        df_bronze=dq_checked,
-        df_data_quality_checks=dq_checked,
     )
 
     latest_version = (dt.history().orderBy(f.col("version").desc()).first()).version
@@ -95,9 +85,6 @@ def adhoc__standalone_master_data_quality_checks(
     schema_reference = get_schema_columns_datahub(s, config.metastore_schema)
     datahub_emit_metadata_with_exception_catcher(
         context=context, config=config, spark=spark, schema_reference=schema_reference
-    )
-    datahub_emit_assertions_with_exception_catcher(
-        context=context, dq_summary_statistics=dq_summary
     )
 
     return Output(

--- a/dagster/src/assets/school_coverage/assets.py
+++ b/dagster/src/assets/school_coverage/assets.py
@@ -33,9 +33,6 @@ from src.utils.adls import ADLSFileClient
 from src.utils.data_quality_descriptions import (
     convert_dq_checks_to_human_readeable_descriptions_and_upload,
 )
-from src.utils.datahub.create_validation_tab import (
-    datahub_emit_assertions_with_exception_catcher,
-)
 from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
@@ -186,9 +183,6 @@ async def coverage_data_quality_results_summary(
         df_data_quality_checks=coverage_data_quality_results,
     )
 
-    datahub_emit_assertions_with_exception_catcher(
-        context=context, dq_summary_statistics=dq_summary_statistics
-    )
     datahub_emit_metadata_with_exception_catcher(
         context=context,
         config=config,

--- a/dagster/src/assets/school_geolocation/assets.py
+++ b/dagster/src/assets/school_geolocation/assets.py
@@ -43,9 +43,6 @@ from src.utils.adls import (
 from src.utils.data_quality_descriptions import (
     convert_dq_checks_to_human_readeable_descriptions_and_upload,
 )
-from src.utils.datahub.create_validation_tab import (
-    datahub_emit_assertions_with_exception_catcher,
-)
 from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
@@ -511,9 +508,6 @@ async def geolocation_data_quality_results_summary(
         df_data_quality_checks=dq_results,
     )
 
-    datahub_emit_assertions_with_exception_catcher(
-        context=context, dq_summary_statistics=dq_summary_statistics
-    )
     datahub_emit_metadata_with_exception_catcher(
         context=context,
         config=config,

--- a/dagster/src/assets/school_list/assets.py
+++ b/dagster/src/assets/school_list/assets.py
@@ -21,10 +21,6 @@ from src.spark.transform_functions import (
 from src.utils.adls import (
     ADLSFileClient,
 )
-
-# from src.utils.datahub.create_validation_tab import (
-#     datahub_emit_assertions_with_exception_catcher,
-# )
 from src.utils.datahub.emit_dataset_metadata import (
     datahub_emit_metadata_with_exception_catcher,
 )
@@ -186,9 +182,6 @@ def qos_school_list_data_quality_results_summary(
         df_data_quality_checks=qos_school_list_data_quality_results,
     )
 
-    # datahub_emit_assertions_with_exception_catcher(
-    #     context=context, dq_summary_statistics=dq_summary_statistics
-    # )
     return Output(dq_summary_statistics, metadata=get_output_metadata(config))
 
 


### PR DESCRIPTION
## What type of PR is this?


- `feat`: Commits that add a new feature

## Summary

Remove custom custom assertions that should show up in a `validation` tab (now called `quality`) tab.

This will remove all emits that creates datahub `assertion` entities with a `spark` metadata which was originally supposed to display the data quality checks.

Example image below shows the checks that _will be removed_
<img width="1117" height="700" alt="image" src="https://github.com/user-attachments/assets/8631d381-68ff-4a90-ba25-6c65d5ee4f63" />
