### PR TITLE
chore: increase dagster deploy timeout

### DIFF
--- a/azure/templates/helm-deploy.yaml
+++ b/azure/templates/helm-deploy.yaml
@@ -63,6 +63,7 @@ jobs:
                 releaseName: dagster
                 namespace: $(kubernetesNamespace)
                 arguments: >
+                  --timeout 6m
                   --values $(Build.SourcesDirectory)/infra/helm/dagster/values.yaml
                   --set dagster-user-deployments.deployments[0].image.repository="$(containerRegistryName).azurecr.io/giga-dagster"
                   --set dagster-user-deployments.deployments[0].image.tag=$(Build.SourceVersion)

--- a/infra/helm/dagster/values.yaml
+++ b/infra/helm/dagster/values.yaml
@@ -426,10 +426,10 @@ dagster-user-deployments:
         # If `readinessProbe` has no `exec` field, then the following default will be used:
         # exec:
         #   command: ["dagster", "api", "grpc-health-check", "-p", "{{ $deployment.port }}"]
-        periodSeconds: 20
-        timeoutSeconds: 10
+        periodSeconds: 40
+        timeoutSeconds: 20
         successThreshold: 1
-        failureThreshold: 15  # Allow roughly 300 seconds to start up by default
+        failureThreshold: 5
 
       # As of 0.14.0, liveness probes are disabled by default. If you want to enable them, it's recommended to also
       # enable startup probes.


### PR DESCRIPTION
## What type of PR is this?

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)
- 
## Summary

What does this PR do


Increases the dagster helm deployment timeout to 6mins and also adjusts the user-deployments timeout in the helm chart
