### PR TITLE
fix: remove whitespace around nocodb mappings

### DIFF
--- a/dagster/src/sensors/adhoc.py
+++ b/dagster/src/sensors/adhoc.py
@@ -504,12 +504,12 @@ def school_qos__gold_csv_to_deltatable_sensor(
             ),
             "adhoc__qos_transforms": OpDestinationMapping(
                 source_filepath=str(path),
-                destination_filepath=f"{constants.gold_folder}/dq-results/qos/transforms/{country_code}/{stem}.csv",
+                destination_filepath=f"{constants.gold_folder}/dq-results/qos/transforms/{country_code}/{stem}.parquet",
                 metastore_schema=metastore_schema,
                 tier=DataTier.TRANSFORMS,
             ),
             "adhoc__publish_qos_to_gold": OpDestinationMapping(
-                source_filepath=f"{constants.gold_folder}/dq-results/qos/transforms/{country_code}/{stem}.csv",
+                source_filepath=f"{constants.gold_folder}/dq-results/qos/transforms/{country_code}/{stem}.parquet",
                 destination_filepath=f"{settings.SPARK_WAREHOUSE_PATH}/{metastore_schema}.db/{country_code}",
                 metastore_schema=metastore_schema,
                 tier=DataTier.GOLD,

--- a/dagster/src/spark/transform_functions.py
+++ b/dagster/src/spark/transform_functions.py
@@ -165,21 +165,30 @@ def map_govt_to_giga_columns(
             continue
 
         govt_casing_map = f.create_map(
-            [f.lit(x) for x in chain(*{k.lower(): k for k in mapping}.items())]
+            [
+                f.lit(x)
+                for x in chain(*{k.lower().strip(): k.strip() for k in mapping}.items())
+            ]
         )
         govt_to_giga_map = f.create_map(
             [
                 f.lit(x)
-                for x in chain(*{k.lower(): v for k, v in mapping.items()}.items())
+                for x in chain(
+                    *{k.lower().strip(): v.strip() for k, v in mapping.items()}.items()
+                )
             ]
         )
         df = df.withColumn(
             source_col,
-            f.coalesce(govt_casing_map[f.lower(f.col(source_col))], f.col(source_col)),
+            f.coalesce(
+                govt_casing_map[f.lower(f.trim(f.col(source_col)))], f.col(source_col)
+            ),
         )
         df = df.withColumn(
             target_col,
-            f.coalesce(govt_to_giga_map[f.lower(f.col(source_col))], f.lit("Unknown")),
+            f.coalesce(
+                govt_to_giga_map[f.lower(f.trim(f.col(source_col)))], f.lit("Unknown")
+            ),
         )
 
     return df


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

What does this PR do

Ensures we do not add mistakenly added whitespace from nocodb value mappings into columns in the pipelines
