### PR TITLE
refactor: update analytics table queries and dependencies

### DIFF
--- a/dagster/src/assets/analytics_tables/assets.py
+++ b/dagster/src/assets/analytics_tables/assets.py
@@ -107,12 +107,12 @@ def all_ping_hourly(context: OpExecutionContext) -> None:
 
 
 @asset(key_prefix=["daily"], group_name="daily", compute_kind="trino")
-def bra_nicbr_daily_tb(context: OpExecutionContext) -> None:
+def bra_nicbr_daily(context: OpExecutionContext) -> None:
     _run_daily(context)
 
 
 @asset(key_prefix=["daily"], group_name="daily", compute_kind="trino")
-def bra_nicbr_registered_tb(context: OpExecutionContext) -> None:
+def bra_nicbr_registered_schools(context: OpExecutionContext) -> None:
     _run_daily(context)
 
 
@@ -144,7 +144,7 @@ def all_ping_daily(context: OpExecutionContext) -> None:
 @asset(
     key_prefix=["daily"],
     group_name="daily",
-    deps=[AssetKey(["daily", "bra_nicbr_daily_tb"])],
+    deps=[AssetKey(["daily", "bra_nicbr_daily"])],
     compute_kind="trino",
 )
 def bra_benchmarkstatus_wow(context: OpExecutionContext) -> None:
@@ -168,10 +168,24 @@ def all_gigameter_valid_test_checker(context: OpExecutionContext) -> None:
     key_prefix=["daily"],
     group_name="daily",
     deps=[
+        AssetKey(["daily", "all_gmeter_only_measurements"]),
+        AssetKey(["daily", "all_mlab_only_measurements"]),
+    ],
+    compute_kind="trino",
+)
+def isp_asn_country_mapping(context: OpExecutionContext) -> None:
+    _run_daily(context)
+
+
+@asset(
+    key_prefix=["daily"],
+    group_name="daily",
+    deps=[
         AssetKey(["daily", "all_gigameter_valid_test_checker"]),
         AssetKey(["daily", "all_gmeter_only_measurements"]),
         AssetKey(["daily", "all_mlab_only_measurements"]),
         AssetKey(["daily", "all_school_master"]),
+        AssetKey(["daily", "isp_asn_country_mapping"]),
     ],
     compute_kind="trino",
 )
@@ -229,10 +243,14 @@ def all_gigameter_appversion_funnel(context: OpExecutionContext) -> None:
 @asset(
     key_prefix=["daily"],
     group_name="daily",
-    deps=[AssetKey(["daily", "all_school_master"])],
+    deps=[
+        AssetKey(["daily", "all_school_master"]),
+        AssetKey(["daily", "all_gmeter_only_measurements"]),
+        AssetKey(["daily", "all_mlab_only_measurements"]),
+    ],
     compute_kind="trino",
 )
-def all_gigameter_funnelsummary_tb_physical(context: OpExecutionContext) -> None:
+def all_gigameter_funnelsummary(context: OpExecutionContext) -> None:
     _run_daily(context)
 
 
@@ -307,7 +325,7 @@ def all_gigameter_inc_ping_daily(context: OpExecutionContext) -> None:
 @asset(
     key_prefix=["daily"],
     group_name="daily",
-    deps=[AssetKey(["daily", "all_gigameter_measurement_data_tb_physical"])],
+    deps=[AssetKey(["daily", "all_gigameter_measurement_data"])],
     compute_kind="trino",
 )
 def mng_gigameter_qos_measurements(context: OpExecutionContext) -> None:
@@ -317,10 +335,24 @@ def mng_gigameter_qos_measurements(context: OpExecutionContext) -> None:
 @asset(
     key_prefix=["daily"],
     group_name="daily",
-    deps=[AssetKey(["daily", "all_gigameter_registered_tb_physical"])],
+    deps=[
+        AssetKey(["daily", "all_gigameter_registered_schools"]),
+        AssetKey(["daily", "all_gigameter_appversion_funnel"]),
+        AssetKey(["daily", "all_gigameter_measurement_data"]),
+    ],
     compute_kind="trino",
 )
 def mng_gigameter_qos_registered(context: OpExecutionContext) -> None:
+    _run_daily(context)
+
+
+@asset(
+    key_prefix=["daily"],
+    group_name="daily",
+    deps=[AssetKey(["incremental", "all_gigameter_measurement_data_incremental"])],
+    compute_kind="trino",
+)
+def all_gigameter_school_daily_troubleshooting(context: OpExecutionContext) -> None:
     _run_daily(context)
 
 
@@ -360,8 +392,24 @@ def all_gigameter_valid_test_checker_incremental(context: OpExecutionContext) ->
         AssetKey(["incremental", "all_gmeter_only_measurements_incremental"]),
         AssetKey(["incremental", "all_mlab_only_measurements_incremental"]),
         AssetKey(["daily", "all_school_master"]),
+        AssetKey(["daily", "isp_asn_country_mapping"]),
     ],
     compute_kind="trino",
 )
 def all_gigameter_measurement_data_incremental(context: OpExecutionContext) -> None:
+    _run_incremental(context)
+
+
+@asset(key_prefix=["incremental"], group_name="incremental", compute_kind="trino")
+def all_ping_hourly_incremental(context: OpExecutionContext) -> None:
+    _run_incremental(context)
+
+
+@asset(
+    key_prefix=["incremental"],
+    group_name="incremental",
+    deps=[AssetKey(["incremental", "all_ping_hourly_incremental"])],
+    compute_kind="trino",
+)
+def all_ping_daily_incremental(context: OpExecutionContext) -> None:
     _run_incremental(context)

--- a/dagster/src/data_quality_checks/utils.py
+++ b/dagster/src/data_quality_checks/utils.py
@@ -144,22 +144,24 @@ def aggregate_report_spark_df(
     )
 
     # Processing for Human Readable Report
-    # Most check keys are "<assertion>-<column>". The duplicate location-rows checks
-    # are named without a hyphen, so their assertion/column are set explicitly.
+    # Most check keys are "<assertion>-<column>"; hyphen-less checks get explicit values.
     is_location_rows_check = f.col("check_key").startswith("duplicate_location_rows")
+    is_geospatial_check = f.col("check_key").isin(
+        "is_in_uninhabited_area", "is_suspect_location", "duplicate_group_flag_50m"
+    )
 
     agg_df = agg_df.withColumn("dq_column", f.col("check_key"))
     agg_df = agg_df.withColumn(
         "column",
-        f.when(is_location_rows_check, f.lit("location_id")).otherwise(
-            f.split(f.col("check_key"), "-").getItem(1)
-        ),
+        f.when(is_location_rows_check, f.lit("location_id"))
+        .when(is_geospatial_check, f.lit("latitude,longitude"))
+        .otherwise(f.split(f.col("check_key"), "-").getItem(1)),
     )
     agg_df = agg_df.withColumn(
         "assertion",
-        f.when(is_location_rows_check, f.lit("duplicate_location_rows")).otherwise(
-            f.split(f.col("check_key"), "-").getItem(0)
-        ),
+        f.when(is_location_rows_check, f.lit("duplicate_location_rows"))
+        .when(is_geospatial_check, f.col("check_key"))
+        .otherwise(f.split(f.col("check_key"), "-").getItem(0)),
     )
 
     # get data descriptions from nocodb

--- a/dagster/src/queries/analytics_tables/README.md
+++ b/dagster/src/queries/analytics_tables/README.md
@@ -14,7 +14,7 @@ Production scripts executed once per day via Dagster. This is the main pipeline 
 Some of these scripts are planned for conversion to the incremental model (hourly cadence) in a future sprint. See the daily README for details.
 
 ### [`incremental/`](incremental/README.md)
-Scripts that run on an **hourly cadence** using an incremental insert pattern — new records are appended rather than the full table being recreated. Currently covers the 4 core measurement pipeline steps (Steps 1–4). Additional scripts (registration, regional) will be added in future iterations.
+Scripts that run on an **hourly cadence** using an incremental insert pattern — new records are appended rather than the full table being recreated. Currently covers the 4 core measurement pipeline steps (Steps 1–4) plus the ping tables. Additional scripts (registration, regional) will be added in future iterations.
 
 ### [`testing/`](testing/README.md)
 Non-production scripts not integrated into the Dagster pipeline. Used for one-off analysis or validating new logic before promoting to `daily/` or `incremental/`.
@@ -51,13 +51,10 @@ SET SESSION mark_distinct_strategy = 'none';    -- avoids memory spikes on DISTI
 SET SESSION query_max_stage_count = 400;        -- needed for country_versions (200+ unions)
 ```
 
-## Sync Tool
+## Source of Truth
 
-Scripts are sourced from two NocoDB tables. Use the sync tool to check for drift:
+These scripts are maintained in [`unicef/giga-data-analytics`](https://github.com/unicef/giga-data-analytics/tree/main/analytics-tables) — author, review, and validate changes there first (that repo has its own NocoDB sync tooling and Trino validation workflow), then port the change here via PR once it's confirmed working. Each `.sql` file here has a matching `@asset`-decorated function in `dagster/src/assets/analytics_tables/assets.py`, named identically — renaming a script requires renaming its Python function too, and updating any other asset's `deps=[AssetKey(...)]` list that references it. Adding a new script requires adding a new `@asset` function; dropping a `.sql` file in alone does nothing.
 
-```bash
-export NOCODB_TOKEN=your_token
-python3 scripts/nocodb_sync.py              # Compare NocoDB vs local
-python3 scripts/nocodb_sync.py --sync       # Pull latest from NocoDB
-python3 scripts/nocodb_sync.py --compare-github  # Compare NocoDB vs GitHub
-```
+One structural difference from `giga-data-analytics`: every `CREATE TABLE` here specifies an explicit `WITH (location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/<table_name>')` clause (templated at execution time — see `_read_statements` in `assets.py`), which `giga-data-analytics`'s copies mostly omit. Preserve this when porting a script update over.
+
+`views/` (reusable Trino views, e.g. `school_connectivity_status_vw`) is intentionally not mirrored here — views aren't rebuilt on a schedule, so they don't fit this repo's daily/incremental asset pattern. They need to be created manually, once, directly in Trino.

--- a/dagster/src/queries/analytics_tables/daily/README.md
+++ b/dagster/src/queries/analytics_tables/daily/README.md
@@ -2,7 +2,7 @@
 
 Production scripts executed **once per day** via Dagster (5:15 AM). All scripts use a drop-and-recreate pattern — the full table is rebuilt on each run.
 
-Scripts are sourced from the **Physical Tables** NocoDB table (`mzq6hlnsicq1r0v`, `Integrated in pipeline = True`).
+Scripts are maintained in [`unicef/giga-data-analytics`](https://github.com/unicef/giga-data-analytics/tree/main/analytics-tables/daily) (itself sourced from the **Physical Tables** NocoDB table, `mzq6hlnsicq1r0v`, `Integrated in pipeline = True`) and ported here via PR once validated there.
 
 ---
 
@@ -15,9 +15,10 @@ Scripts are sourced from the **Physical Tables** NocoDB table (`mzq6hlnsicq1r0v`
 | `all_gmeter_only_measurements.sql` | `default.all_gmeter_only_measurements` | GigaMeter app raw measurements (Step 1) | `gigameter_production_db` | Yes — Step 1 incremental in progress |
 | `all_mlab_only_measurements.sql` | `default.all_mlab_only_measurements` | MLab network test measurements (Step 2) | `gigameter_production_db` | Yes — Step 2 incremental in progress |
 | `all_gigameter_valid_test_checker.sql` | `default.all_gigameter_valid_test_checker` | Per-measurement quality validation (Step 3) | Steps 1 & 2 | Yes — Step 3 incremental in progress |
-| `all_gigameter_measurement_data.sql` | `default.all_gigameter_measurement_data` | Consolidated validated measurements (Step 4) | Steps 1, 2, & 3 | Yes — Step 4 incremental in progress |
-| `all_gigameter_measurement_data_daily.sql` | `default.all_gigameter_measurement_data_daily` | Daily aggregation per school (weekdays only) | `all_gigameter_measurement_data` | |
-| `all_gigameter_measurement_data_weekly.sql` | `default.all_gigameter_measurement_data_weekly` | Weekly aggregation per school with percentile speeds | `all_gigameter_measurement_data` | |
+| `isp_asn_country_mapping.sql` | `default.isp_asn_country_mapping` | Canonical ISP name/ASN lookup, resolves ASN-truncation variants per country | Steps 1 & 2 | |
+| `all_gigameter_measurement_data.sql` | `default.all_gigameter_measurement_data` | Consolidated validated measurements (Step 4) | Steps 1, 2, & 3, ISP/ASN mapping | Yes — Step 4 incremental in progress |
+| `all_gigameter_measurement_data_daily.sql` | `default.all_gigameter_measurement_data_daily` | Daily aggregation per school+device (weekdays only) — p5/p50/p95 speed metrics, summed data volume, JSON categorical breakdowns, school attributes | `all_gigameter_measurement_data` | |
+| `all_gigameter_measurement_data_weekly.sql` | `default.all_gigameter_measurement_data_weekly` | Weekly aggregation per school+device (weekdays only) — identical column structure to daily table | `all_gigameter_measurement_data` | |
 | `all_gigameter_measurement_data_tb_physical.sql` | `default.all_gigameter_measurement_data_tb_physical` | Backwards-compatible measurement data variant | Steps 1 & 2 | |
 | `all_ping_hourly.sql` | `default.all_ping_hourly` | Hourly ping/uptime aggregation per device-school | `gigameter_production_db.connectivity_ping_checks` | |
 | `all_ping_daily.sql` | `default.all_ping_daily` | Daily ping aggregation | `all_ping_hourly` | |
@@ -28,18 +29,19 @@ Scripts are sourced from the **Physical Tables** NocoDB table (`mzq6hlnsicq1r0v`
 | `all_gigameter_registered_schools.sql` | `default.all_gigameter_registered_schools` | School-level registration & activity summary | measurement data, `all_school_master` | Planned (2nd iteration) |
 | `all_gigameter_registered_devices.sql` | `default.all_gigameter_registered_devices` | Device-level registration & activity summary | measurement data, appversion funnel | Planned (2nd iteration) |
 | `all_gigameter_school_consistency_history.sql` | `default.all_gigameter_school_consistency_history` | Weekly 30-day rolling consistency score per school | measurement data | |
-| `all_gigameter_funnelsummary_tb_physical.sql` | `default.all_gigameter_funnelsummary_tb_physical` | Country-level adoption funnel & QoS source summary | measurement data, `all_school_master`, QoS tables | |
-| `bra_nicbr_registered_tb.sql` | `default.bra_nicbr_registered_tb` | Brazil school NIC.BR registration summary | `school_master.bra`, `qos.bra`, FUST | Planned (2nd iteration) |
-| `bra_nicbr_daily_tb.sql` | `default.bra_nicbr_daily_tb` | Daily Brazil NIC.BR speed data with benchmark flags | `qos.bra`, `school_master.bra`, FUST | Planned (2nd iteration) |
-| `bra_benchmarkstatus_wow.sql` | `default.bra_benchmarkstatus_wow` | Brazil weekly benchmark status with WoW changes | `bra_nicbr_daily_tb` | |
+| `all_gigameter_funnelsummary.sql` | `default.all_gigameter_funnelsummary` | Country-level adoption funnel & QoS source summary | measurement data, `all_school_master`, QoS tables | |
+| `bra_nicbr_registered_schools.sql` | `default.bra_nicbr_registered_schools` | Brazil school NIC.BR registration summary | `school_master.bra`, `qos.bra`, FUST | Planned (2nd iteration) |
+| `bra_nicbr_daily.sql` | `default.bra_nicbr_daily` | Daily Brazil NIC.BR speed data with benchmark flags | `qos.bra`, `school_master.bra`, FUST | Planned (2nd iteration) |
+| `bra_benchmarkstatus_wow.sql` | `default.bra_benchmarkstatus_wow` | Brazil weekly benchmark status with WoW changes | `bra_nicbr_daily` | |
 | `mng_gigameter_qos_registered.sql` | `default.mng_gigameter_qos_registered` | Mongolia school registration (GigaMeter + LibreRouter) | `qos_raw.mng`, `school_master.mng` | Planned (2nd iteration) |
 | `mng_gigameter_qos_measurements.sql` | `default.mng_gigameter_qos_measurements` | Mongolia daily measurements (GigaMeter + LibreRouter) | `qos.mng`, `school_master.mng` | Planned (2nd iteration) |
+| `all_gigameter_school_daily_troubleshooting.sql` | `default.all_gigameter_school_daily_troubleshooting` | Pre-aggregated school+day summary for Superset T0 troubleshooting | `all_gigameter_measurement_data_incremental` (separate hourly pipeline) | |
 
 ---
 
 ## Execution Order
 
-Scripts are executed sequentially in the order they appear in the NocoDB physical tables view. Dependencies are noted where relevant — these must be respected if the order is ever changed.
+Scripts are executed in dependency order via the `deps=[AssetKey(...)]` declarations in `dagster/src/assets/analytics_tables/assets.py`. The list below mirrors that order for reference — if it drifts from `assets.py`, `assets.py` is authoritative.
 
 ```
  1. country_versions
@@ -47,25 +49,27 @@ Scripts are executed sequentially in the order they appear in the NocoDB physica
  3. all_gmeter_only_measurements
  4. all_mlab_only_measurements
  5. all_gigameter_valid_test_checker           ← #3, #4
- 6. all_gigameter_measurement_data             ← #2, #3, #4, #5
- 7. all_gigameter_measurement_data_tb_physical ← #2, #3, #4
- 8. all_gigameter_measurement_data_daily       ← #6
- 9. all_gigameter_measurement_data_weekly      ← #6
-10. all_gigameter_appversion_funnel            ← #2, #6
-11. all_gigameter_registered_tb_physical       ← #2, #7, #10
-12. all_gigameter_registered_schools           ← #2, #6
-13. bra_nicbr_daily_tb
-14. bra_nicbr_registered_tb
-15. all_gigameter_funnelsummary_tb_physical    ← #2
-16. bra_benchmarkstatus_wow                    ← #13
-17. all_gigamaps_realtimeconnectivity
-18. mng_gigameter_qos_measurements             ← #7
-19. mng_gigameter_qos_registered               ← #11
-20. all_gigameter_registered_devices           ← #2, #6, #10
-21. all_ping_hourly
-22. all_ping_daily                             ← #21
-23. all_gigameter_inc_ping_daily               ← #6, #10, #22
-24. all_gigameter_school_consistency_history   ← #3, #6
+ 6. isp_asn_country_mapping                    ← #3, #4
+ 7. all_gigameter_measurement_data             ← #2, #3, #4, #5, #6
+ 8. all_gigameter_measurement_data_tb_physical ← #2, #3, #4
+ 9. all_gigameter_measurement_data_daily       ← #7
+10. all_gigameter_measurement_data_weekly      ← #7
+11. all_gigameter_appversion_funnel            ← #2, #7
+12. all_gigameter_registered_tb_physical       ← #2, #8, #11
+13. all_gigameter_registered_schools           ← #2, #7
+14. bra_nicbr_daily
+15. bra_nicbr_registered_schools
+16. all_gigameter_funnelsummary                ← #2
+17. bra_benchmarkstatus_wow                    ← #14
+18. all_gigamaps_realtimeconnectivity
+19. mng_gigameter_qos_measurements             ← #7
+20. mng_gigameter_qos_registered               ← #7, #11, #13
+21. all_gigameter_registered_devices           ← #2, #7, #11
+22. all_ping_hourly
+23. all_ping_daily                             ← #22
+24. all_gigameter_inc_ping_daily               ← #7, #11, #23
+25. all_gigameter_school_consistency_history   ← #3, #7
+26. all_gigameter_school_daily_troubleshooting ← incremental pipeline (all_gigameter_measurement_data_incremental), not part of this daily chain
 ```
 
 ---

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_funnelsummary.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_funnelsummary.sql
@@ -4,7 +4,7 @@
 
 -- ==============================================================================
 -- Script Name:     all_gigameter_funnelsummary.sql
--- Table Created:   default.all_gigameter_funnelsummary_tb_physical
+-- Table Created:   default.all_gigameter_funnelsummary
 -- Schema:          default
 -- Pipeline Status: Active (Integrated: true)
 --
@@ -12,34 +12,37 @@
 --   Country-level summary of the GigaMeter adoption funnel and measurement
 --   source distribution. Combines school registration counts, GigaMeter and
 --   MLab measurement activity, connectivity status breakdowns, and regional
---   QoS provider data (Brazil NIC.BR, Mongolia LibreRouter, Kenya providers).
+--   QoS provider data (Brazil NIC.BR, Mongolia LibreRouter, Kenya providers,
+--   South Africa Isizwe).
 --
 -- Dependencies:
 --   - gigamaps_production_db.public.schools (school registry)
 --   - gigameter_production_db.public.school (GigaMeter registration)
---   - default.all_gigameter_measurement_data (GigaMeter measurements)
+--   - default.all_gmeter_only_measurements (GigaMeter measurements)
 --   - default.all_mlab_only_measurements (MLab measurements)
 --   - default.all_school_master (school metadata and geography)
 --   - custom_dataset.country_geography (region and continent classification)
---   - qos.bra, qos.mng, qos.ken, qos.vct (country QoS measurement sources)
+--   - qos.bra, qos.mng, qos.ken, qos.vct, qos.zaf (country QoS measurement sources)
+--   - lstringer.school_connectivity_status_vw (connectivity classification --
+--     see analytics-tables/views/school_connectivity_status_vw.sql)
 --
--- Output Columns:  ~30 columns
+-- Output Columns:  ~34 columns
 -- Primary Key:     country
 -- Granularity:     One row per country
 --
 -- Run Notes:
 --   Recurring — refresh daily or weekly. Regional provider breakdowns are
---   scoped to Brazil, Mongolia, Kenya, and Saint Vincent & Grenadines.
+--   scoped to Brazil, Mongolia, Kenya, Saint Vincent & Grenadines, and South Africa.
 --
--- Last Updated:    2025-10-31 / Luke Stringer
+-- Last Updated:    2026-07-17 / Luke Stringer
 -- ==============================================================================
 
 
-  CREATE TABLE IF NOT EXISTS  default.all_gigameter_funnelsummary_tb_physical
-WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_funnelsummary_tb_physical'
-)
-AS (
+  CREATE TABLE IF NOT EXISTS  default.all_gigameter_funnelsummary
+  WITH (
+      location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_funnelsummary'
+  )
+  AS (
 
 WITH registered AS (
 SELECT
@@ -82,9 +85,9 @@ SELECT
     school_id_giga
 -- select *
 FROM
-  default.all_gmeter_measurements_vw
-WHERE
-  school_record_deleted is null
+  default.all_gmeter_only_measurements
+-- no school_record_deleted filter needed here -- all_gmeter_only_measurements'
+-- own school_lookup CTE already excludes deleted schools at the source
 )
 
 
@@ -95,64 +98,24 @@ select
     school_id_govt,
     school_id_giga
 from
-  default.all_mlab_measurements_vw
-where
-  deleted is null
+  default.all_mlab_only_measurements
+-- no deleted filter needed here -- all_mlab_only_measurements' own school_lookup
+-- CTE already excludes deleted schools at the source (and the old view's `deleted`
+-- column was always NULL for MLab anyway, so this was a no-op filter)
 )
 
 
 
+-- Reads the shared connectivity classification view instead of re-deriving it here --
+-- see analytics-tables/views/school_connectivity_status_vw.sql for the logic and why
+-- it has a 'Disputed' bucket (this used to silently drop those rows from every count).
 , connectivity_stats AS (
-
-   select
-    DISTINCT
-    c.name as country,
-    school.giga_id_school,
-    school.name as school_name,
-    case
-      when
-        connectivity_Status in ( 'good', 'moderate')
-      then
-        giga_id_school
-      else
-        null
-      end as connected_giga_id_schools,
-    case
-      when
-        connectivity = false and connectivity_status = 'no'
-      then
-        giga_id_school
-      else
-        null
-      end as not_connected_giga_id_schools,
-
-    case
-      when
-        connectivity is null and connectivity_status = 'unknown'
-      then
-        giga_id_school
-      else
-        null
-      end as unknown_connectivity_giga_id_schools
-
-
--- select distinct connectivity
-from
-gigamaps_production_db.public.connection_statistics_schoolweeklystatus conn_stats
-
-inner JOIN
-  gigamaps_production_db.public.schools_school AS school
-ON
-  school.id = conn_stats.school_id
-AND
-  school.last_weekly_status_id = conn_stats.id
-LEFT JOIN
-  gigamaps_production_db.public.locations_country AS c
-ON
-  c.id = school.country_id
-  WHERE
-    school.deleted is null
-
+    SELECT
+        v.gigamaps_country AS country,
+        v.school_id_giga,
+        v.connectivity_gigamaps
+    FROM
+        lstringer.school_connectivity_status_vw v
 )
 
 
@@ -160,9 +123,10 @@ ON
 
 SELECT
   country,
-  count(distinct connected_giga_id_schools) as connected_schools,
-  count(distinct not_connected_giga_id_schools) as not_connected_schools,
-  count(distinct unknown_connectivity_giga_id_schools) as unknown_connectivity_schools
+  count(distinct case when connectivity_gigamaps = 'Connected' then school_id_giga end) as connected_schools,
+  count(distinct case when connectivity_gigamaps = 'NotConnected' then school_id_giga end) as not_connected_schools,
+  count(distinct case when connectivity_gigamaps = 'Unknown' then school_id_giga end) as unknown_connectivity_schools,
+  count(distinct case when connectivity_gigamaps = 'Disputed' then school_id_giga end) as disputed_connectivity_schools
 from
   connectivity_stats
 GROUP BY
@@ -274,6 +238,16 @@ from qos.vct
 GROUP BY 1,2
 )
 
+, qos_zaf_schools as (
+SELECT
+     'South Africa' as country,
+     'Isizwe' as provider,
+     MIN(date) as initial_registration_date_qos_zaf,
+     COUNT(DISTINCT school_id_giga) qos_zaf_schools
+from qos.zaf
+GROUP BY 1,2
+)
+
 
 
 , gigameter_schools as (
@@ -344,6 +318,9 @@ SELECT
 -- Saint Vincent and the Grenadines (VCT)
   CAST(qosvct.qos_vct_schools AS BIGINT) AS qos_vct_schools,
   CAST(qosvct.initial_registration_date_qos_vct AS DATE) AS initial_registration_date_qos_vct,
+-- South Africa (ZAF)
+  CAST(qoszaf.qos_zaf_schools AS BIGINT) AS qos_zaf_schools,
+  CAST(qoszaf.initial_registration_date_qos_zaf AS DATE) AS initial_registration_date_qos_zaf,
 -- calculated cols
   CAST(con.connected_schools AS BIGINT) AS connected_schools,
 
@@ -355,7 +332,15 @@ SELECT
 
   CAST(con.unknown_connectivity_schools AS BIGINT) AS unknown_connectivity_schools,
 
-  CAST(ROUND(((con.unknown_connectivity_schools * DECIMAL '100.0') / NULLIF(gigamaps.gigamaps_schools, 0)), 2) AS DOUBLE) AS unknown_connectivity_schools_percentage
+  CAST(ROUND(((con.unknown_connectivity_schools * DECIMAL '100.0') / NULLIF(gigamaps.gigamaps_schools, 0)), 2) AS DOUBLE) AS unknown_connectivity_schools_percentage,
+
+  -- Schools where GigaMaps' connectivity_status and its own weekly connectivity
+  -- boolean disagree -- previously silently excluded from every bucket above.
+  -- Usually 0; only non-zero when the two signals haven't caught up with each
+  -- other yet (see school_connectivity_status_vw.sql for the mechanics).
+  CAST(con.disputed_connectivity_schools AS BIGINT) AS disputed_connectivity_schools,
+
+  CAST(ROUND(((con.disputed_connectivity_schools * DECIMAL '100.0') / NULLIF(gigamaps.gigamaps_schools, 0)), 2) AS DOUBLE) AS disputed_connectivity_schools_percentage
 
 
 FROM
@@ -404,6 +389,10 @@ left join
   qos_vct_schools qosvct
 on
   gigamaps.country = qosvct.country
+left join
+  qos_zaf_schools qoszaf
+on
+  gigamaps.country = qoszaf.country
 
 
-  )
+   )

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data.sql
@@ -1,10 +1,11 @@
 
 
  CREATE TABLE IF NOT EXISTS default.all_gigameter_measurement_data
-WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data'
-)
-AS (
+ WITH (
+     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data',
+     partitioned_by = ARRAY['country']
+ )
+ AS (
 
 
 -- =============================================================================
@@ -17,7 +18,7 @@ AS (
 --
 -- SCHOOL MASTER FIELDS ADDED:
 --   - admin1, admin2 (administrative regions)
---   - connectivity, connectivity_type_govt
+--   - connectivity, connectivity_type
 --   - cellular_coverage_type
 --   - education_level
 --   - electricity_availability
@@ -40,13 +41,14 @@ WITH  measure AS (
       s1.admin1,
       s1.admin2,
       s1.connectivity,
-      s1.connectivity_type_govt,
+      s1.connectivity_type,
       s1.cellular_coverage_type,
       s1.education_level,
       s1.electricity_availability,
       s1.fiber_node_distance,
       s1.school_area_type,
       s1.school_funding_type,
+      s1.download_speed_contracted,
       --s1.deleted,                      -- REMOVED: Filtered upstream
       s1.latitude,
       s1.longitude
@@ -77,13 +79,14 @@ UNION ALL
       s2.admin1,
       s2.admin2,
       s2.connectivity,
-      s2.connectivity_type_govt,
+      s2.connectivity_type,
       s2.cellular_coverage_type,
       s2.education_level,
       s2.electricity_availability,
       s2.fiber_node_distance,
       s2.school_area_type,
       s2.school_funding_type,
+      s2.download_speed_contracted,
      -- s2.deleted,                       -- REMOVED: Filtered upstream
       s2.latitude,
       s2.longitude
@@ -164,15 +167,26 @@ SELECT
     CAST(m.notes AS VARCHAR) AS notes,
 
     -- -------------------------------------------------------------------------
+    -- ISP/ASN Canonical Mapping
+    -- Resolves ASN-truncation variants of the same ISP to a single canonical
+    -- name/ASN per country, and flags likely shared infrastructure (CDN/hosting)
+    -- -- see analytics-tables/daily/isp_asn_country_mapping.sql
+    -- -------------------------------------------------------------------------
+    CAST(map.canonical_isp_name AS VARCHAR) AS isp_name_clean,
+    CAST(map.canonical_asn AS VARCHAR) AS isp_asn_clean,
+    CAST(map.isp_key AS VARCHAR) AS isp_key,
+    CAST(map.is_likely_shared_infra AS BOOLEAN) AS is_likely_shared_infra,
+
+    -- -------------------------------------------------------------------------
     -- WiFi Connection Details
     -- -------------------------------------------------------------------------
-    CAST(m.detected_wifi_ssid AS VARCHAR) AS detected_wifi_ssid,
-    CAST(m.detected_wifi_model AS VARCHAR) AS detected_wifi_model,
-    CAST(m.detected_wifi_quality AS INTEGER) AS detected_wifi_quality,
-    CAST(m.detected_wifi_signal AS DECIMAL(10,2)) AS detected_wifi_signal,
-    CAST(m.detected_wifi_tx_rate AS INTEGER) AS detected_wifi_tx_rate,
-    CAST(m.detected_wifi_channel AS INTEGER) AS detected_wifi_channel,
-    CAST(m.detected_wifi_frequency AS INTEGER) AS detected_wifi_frequency,
+    CAST(m.detected_wifi_ssid AS VARCHAR) AS wifi_ssid,
+    CAST(m.detected_wifi_model AS VARCHAR) AS wifi_model,
+    CAST(m.detected_wifi_quality AS INTEGER) AS wifi_quality,
+    CAST(m.detected_wifi_signal AS DECIMAL(10,2)) AS wifi_signal,
+    CAST(m.detected_wifi_tx_rate AS INTEGER) AS wifi_tx_rate,
+    CAST(m.detected_wifi_channel AS INTEGER) AS wifi_channel,
+    CAST(m.detected_wifi_frequency AS INTEGER) AS wifi_frequency,
 
     -- -------------------------------------------------------------------------
     -- Device Identification
@@ -226,15 +240,15 @@ SELECT
     -- These alias raw values as avg_*/total_* for existing dashboard compatibility
     -- TODO: Remove after single country dashboard built and tested
     -- -------------------------------------------------------------------------
-    CAST(m.download_speed AS REAL) as avg_download_speed,           -- Alias: In Mbps
-    CAST(m.upload_speed AS REAL) as avg_upload_speed,               -- Alias: In Mbps
-    CAST(m.latency AS BIGINT) as avg_latency,                         -- Alias: In milliseconds
-    CAST(m.data_downloaded_gb AS REAL) as avg_data_downloaded_gb,   -- Alias: In GB
-    CAST(m.data_uploaded_gb AS REAL) as avg_data_uploaded_gb,       -- Alias: In GB
-    CAST(m.data_usage_gb AS REAL) as avg_data_usage_gb,             -- Alias: In GB
-    CAST(m.data_downloaded_gb AS REAL) as total_data_downloaded_gb, -- Alias: In GB
-    CAST(m.data_uploaded_gb AS REAL) as total_data_uploaded_gb,     -- Alias: In GB
-    CAST(m.data_usage_gb AS REAL) as total_data_usage_gb,           -- Alias: In GB
+    --CAST(m.download_speed AS REAL) as avg_download_speed,           -- Alias: In Mbps
+    --CAST(m.upload_speed AS REAL) as avg_upload_speed,               -- Alias: In Mbps
+    --CAST(m.latency AS BIGINT) as avg_latency,                         -- Alias: In milliseconds
+    --CAST(m.data_downloaded_gb AS REAL) as avg_data_downloaded_gb,   -- Alias: In GB
+    --CAST(m.data_uploaded_gb AS REAL) as avg_data_uploaded_gb,       -- Alias: In GB
+    --CAST(m.data_usage_gb AS REAL) as avg_data_usage_gb,             -- Alias: In GB
+    --CAST(m.data_downloaded_gb AS REAL) as total_data_downloaded_gb, -- Alias: In GB
+    --CAST(m.data_uploaded_gb AS REAL) as total_data_uploaded_gb,     -- Alias: In GB
+    --CAST(m.data_usage_gb AS REAL) as total_data_usage_gb,           -- Alias: In GB
 
     -- -------------------------------------------------------------------------
     -- School Master Enrichment Fields
@@ -243,16 +257,26 @@ SELECT
     CAST(m.admin1 AS VARCHAR) AS admin1,
     CAST(m.admin2 AS VARCHAR) AS admin2,
     CAST(m.connectivity AS VARCHAR) AS connectivity,
-    CAST(m.connectivity_type_govt AS VARCHAR) AS connectivity_type_govt,
+    CAST(m.connectivity_type AS VARCHAR) AS connectivity_type,
     CAST(m.cellular_coverage_type AS VARCHAR) AS cellular_coverage_type,
     CAST(m.education_level AS VARCHAR) AS education_level,
     CAST(m.electricity_availability AS VARCHAR) AS electricity_availability,
     CAST(m.fiber_node_distance AS DOUBLE) AS fiber_node_distance,
     CAST(m.school_area_type AS VARCHAR) AS school_area_type,
     CAST(m.school_funding_type AS VARCHAR) AS school_funding_type,
+    CAST(m.download_speed_contracted AS VARCHAR) AS download_speed_contracted,
     --m.deleted,                          -- REMOVED: Filtered upstream
     CAST(m.latitude AS DOUBLE) AS latitude,
     CAST(m.longitude AS DOUBLE) AS longitude,
+
+    -- -------------------------------------------------------------------------
+    -- Geolocation (from GigaMeter app; NULL for MLab)
+    -- -------------------------------------------------------------------------
+    CAST(m.detected_latitude AS DOUBLE)             AS detected_latitude,
+    CAST(m.detected_longitude AS DOUBLE)            AS detected_longitude,
+    CAST(m.detected_location_is_flagged AS BOOLEAN) AS detected_location_is_flagged,
+    CAST(m.detected_location_distance AS DOUBLE)    AS detected_location_distance,
+    CAST(m.detected_location_accuracy AS DOUBLE)    AS detected_location_accuracy,
 
     -- -------------------------------------------------------------------------
     -- Country-Specific Fields
@@ -261,6 +285,7 @@ SELECT
     CAST(c.canton_name AS VARCHAR) AS canton_bih_only,    -- Bosnia and Herzegovina only
     CAST(cc.status AS VARCHAR) AS connectivity_credits_school,  -- Connectivity credits pilot program
     CAST(p.zaf_province AS VARCHAR) AS province_zaf_only,
+    CAST(l.zone AS VARCHAR) as education_zone_lka_only,
 
     -- -------------------------------------------------------------------------
     -- Measurement Protocol
@@ -299,6 +324,11 @@ LEFT JOIN
   default.all_gigameter_valid_test_checker  mf
 on
   m.measurement_id = mf.measurement_id
+-- JOIN: ISP/ASN canonical mapping -- see isp_asn_country_mapping.sql
+LEFT JOIN default.isp_asn_country_mapping map
+  ON  map.iso3_code    = m.iso3_code
+  AND map.isp_name_raw = m.detected_isp_raw
+  AND map.isp_asn_raw  = m.detected_isp_asn
 -- JOIN: Bosnia canton mapping (country-specific enrichment)
 -- Only populates for schools in Bosnia and Herzegovina
 LEFT JOIN lstringer.bih_school_canton_mapping_vw c
@@ -311,6 +341,10 @@ LEFT JOIN lstringer.connectivity_credit_pilot_schools cc
 
 LEFT JOIN lstringer.zaf_province_mapping p
   on m.school_id_giga = p.school_id_giga
+
+LEFT JOIN lstringer.lka_school_education_zones l
+  on m.school_id_govt = l.school_id_govt
+  and m.iso3_code = l.iso3_code
 
 -- where m.date > cast('2024-01-01' as date)       -- added
  )

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_tb_physical.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_tb_physical.sql
@@ -69,7 +69,7 @@ WITH  measure AS (
       s1.admin1,
       s1.admin2,
       s1.connectivity,
-      s1.connectivity_type_govt,
+      s1.connectivity_type,
       s1.cellular_coverage_type,
       s1.education_level,
       s1.electricity_availability,
@@ -105,7 +105,7 @@ UNION ALL
       s2.admin1,
       s2.admin2,
       s2.connectivity,
-      s2.connectivity_type_govt,
+      s2.connectivity_type,
       s2.cellular_coverage_type,
       s2.education_level,
       s2.electricity_availability,
@@ -255,7 +255,7 @@ SELECT
     m.admin1,
     m.admin2,
     m.connectivity,
-    m.connectivity_type_govt,
+    m.connectivity_type,
     m.cellular_coverage_type,
     m.education_level,
     m.electricity_availability,
@@ -280,7 +280,8 @@ SELECT
     -- -------------------------------------------------------------------------
     c.canton_name AS canton_bih_only,    -- Bosnia and Herzegovina only
     cc.status AS connectivity_credits_school,  -- Connectivity credits pilot program
-    p.zaf_province as province_zaf_only
+    p.zaf_province as province_zaf_only,
+    l.zone as education_zone_lka_only
 
 FROM measure m
 
@@ -296,6 +297,10 @@ LEFT JOIN lstringer.connectivity_credit_pilot_schools cc
 
 LEFT JOIN lstringer.zaf_province_mapping p
   on m.school_id_giga = p.school_id_giga
+
+LEFT JOIN lstringer.lka_school_education_zones l
+  on m.school_id_govt = l.school_id_govt
+  and m.iso3_code = l.iso3_code
 
 -- where m.date > cast('2024-01-01' as date)       -- added
 )

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_devices.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_devices.sql
@@ -257,7 +257,8 @@ SELECT
   END AS VARCHAR) AS install_status,
   CAST(c.canton_name AS VARCHAR) AS canton_bih_only,
   CAST(CASE WHEN cc.status IS NULL THEN 'not included' ELSE cc.status END AS VARCHAR) AS connectivity_credits_school,
-  CAST(p.zaf_province AS VARCHAR) AS province_zaf_only
+  CAST(p.zaf_province AS VARCHAR) AS province_zaf_only,
+  CAST(l.zone AS VARCHAR) as education_zone_lka_only
 FROM
   pre_table pt
 left join
@@ -271,5 +272,12 @@ on
 
 LEFT JOIN lstringer.zaf_province_mapping p
   on pt.school_id_giga = p.school_id_giga
+
+
+
+LEFT JOIN lstringer.lka_school_education_zones l
+  on pt.school_id_govt = l.school_id_govt
+  and pt.iso3_code = l.iso3_code
+
 
   )

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
@@ -19,10 +19,13 @@
 --
 -- Dependencies:
 --   - gigameter_production_db.public.school (GigaMeter school registrations)
+--   - gigameter_production_db.public.dailycheckapp_school (registration/check-in events)
 --   - default.all_gigameter_measurement_data (consolidated measurement history)
 --   - default.all_school_master (school metadata and geography)
+--   - lstringer.school_connectivity_status_vw (GigaMaps connectivity classification
+--     -- see analytics-tables/views/school_connectivity_status_vw.sql)
 --
--- Output Columns:  ~30 columns
+-- Output Columns:  ~33 columns
 -- Primary Key:     school_id_giga
 -- Granularity:     One row per registered school
 --
@@ -30,15 +33,26 @@
 --   Recurring — refresh daily or on-demand to reflect latest activity.
 --   Connectivity status thresholds: live ≤21 days since last measurement,
 --   at-risk 21–30 days, drop-off >30 days.
+--   last_device_installed_id is device_hardware_id from the most recent
+--   dailycheckapp_school row per school -- only ~31% populated at source,
+--   NULL is expected/common, not a bug. last_device_installed_date is
+--   separately ~75% populated.
 --
--- Last Updated:    2025-10-31 / Luke Stringer
+-- Partitioned by: country (12 Superset datasets on dashboard 21 filter this
+-- table by a single country each -- unpartitioned, every one of them scanned
+-- the full table)
+--
+-- Last Updated:    2026-07-30 / Luke Stringer
 -- ==============================================================================
 
-CREATE TABLE IF NOT EXISTS default.all_gigameter_registered_schools
+-- DROP TABLE IF EXISTS default.all_gigameter_registered_schools;
+
+CREATE TABLE default.all_gigameter_registered_schools
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_registered_schools'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_registered_schools',
+    partitioned_by = ARRAY['country']
 )
-as (
+AS (
 
 with
 
@@ -131,6 +145,27 @@ WHERE
 )
 
 
+-- most recently installed device per school (by registration/check-in event, not by
+-- currently-active status -- an install stays "most recent" even if later logged out).
+-- device_hardware_id is only ~31% populated at source; NULL here is expected.
+, last_device_installed AS (
+    SELECT
+        giga_id_school AS school_id_giga,
+        device_hardware_id AS last_device_installed_id,
+        created_at AS last_device_installed_date
+    FROM (
+        SELECT
+            giga_id_school,
+            device_hardware_id,
+            created_at,
+            ROW_NUMBER() OVER (PARTITION BY giga_id_school ORDER BY created_at DESC) AS row_num
+        FROM
+            gigameter_production_db.public.dailycheckapp_school
+    ) AS d
+    WHERE row_num = 1
+)
+
+
 -- get data from measurement table
 , measurement_data as (
 SELECT
@@ -185,6 +220,8 @@ SELECT
   CAST(r.devices_still_logged_in AS BIGINT) AS devices_still_logged_in,
   CAST(data.num_devices_measured AS BIGINT) AS num_devices_measured,
   CAST(app.max_app_version AS VARCHAR) AS max_app_version_gigameter,
+  CAST(dev.last_device_installed_id AS VARCHAR) AS last_device_installed_id,
+  CAST(dev.last_device_installed_date AS TIMESTAMP) AS last_device_installed_date,
   -- provider info (MAP — pass through)
   data.detected_isp_nested,
   data.detected_isp_asn_nested,
@@ -196,7 +233,15 @@ SELECT
   CAST(master.latitude AS DOUBLE) AS latitude,
   CAST(master.longitude AS DOUBLE) AS longitude,
   -- connection info
+  -- connectivity: from all_school_master (government-reported, optionally
+  -- overridden by real-time GigaMeter/MLab/QoS measurement presence) --
+  -- unchanged name/values, kept as-is for downstream dashboard compatibility.
+  -- connectivity_gigamaps: from GigaMaps' own weekly connectivity monitoring, a
+  -- separate signal -- see analytics-tables/views/school_connectivity_status_vw.sql.
+  -- These two can and do disagree (investigated 2026-07-31) -- do not assume they
+  -- mean the same thing.
   CAST(master.connectivity AS VARCHAR) AS connectivity,
+  CAST(gmconn.connectivity_gigamaps AS VARCHAR) AS connectivity_gigamaps,
   CAST(master.connectivity_type_govt AS VARCHAR) AS connectivity_type_govt,
   CAST(master.cellular_coverage_type AS VARCHAR) AS cellular_coverage_type,
   CAST(master.school_area_type AS VARCHAR) AS school_area_type,
@@ -208,6 +253,7 @@ SELECT
   CAST(c.canton_name AS VARCHAR) AS canton_bih_only,
   CAST(cc.status AS VARCHAR) AS connectivity_credits_school,
   CAST(p.zaf_province AS VARCHAR) AS province_zaf_only,
+  CAST(l.zone AS VARCHAR) as education_zone_lka_only,
   -- calculated columns
   -- to be removed once integrated with consistency indicator + IQB-edu
   CAST(CASE
@@ -237,6 +283,14 @@ LEFT JOIN
   registration_attempts r
 ON
   master.school_id_giga = r.school_id_giga
+LEFT JOIN
+  last_device_installed dev
+ON
+  master.school_id_giga = dev.school_id_giga
+LEFT JOIN
+  lstringer.school_connectivity_status_vw gmconn
+ON
+  master.school_id_giga = gmconn.school_id_giga
 -- canton mapping
 left join
   lstringer.bih_school_canton_mapping_vw c
@@ -252,5 +306,12 @@ LEFT JOIN
   lstringer.zaf_province_mapping p
 on
   master.school_id_giga = p.school_id_giga
+
+
+LEFT JOIN lstringer.lka_school_education_zones l
+  on master.school_id_govt = l.school_id_govt
+  and master.iso3_code = l.iso3_code
+
+
 
   );

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_tb_physical.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_tb_physical.sql
@@ -465,7 +465,8 @@ vt AS (
         c.canton_name AS canton_bih_only,
         cc.status AS connectivity_credits_school,
         cs.connectivity_gigamaps,
-        p.zaf_province as province_zaf_only
+        p.zaf_province as province_zaf_only,
+        CAST(l.zone AS VARCHAR) as education_zone_lka_only
 
     FROM pre_table pt
     -- FULL JOIN to include all schools, even those without measurements
@@ -482,6 +483,11 @@ vt AS (
 
     LEFT JOIN lstringer.zaf_province_mapping p
       on master.school_id_giga = p.school_id_giga
+
+
+    LEFT JOIN lstringer.lka_school_education_zones l
+      on master.school_id_govt = l.school_id_govt
+      and master.iso3_code = l.iso3_code
 )
 
 
@@ -552,7 +558,8 @@ SELECT
     canton_bih_only,
     connectivity_credits_school,
     connectivity_gigamaps,
-    province_zaf_only
+    province_zaf_only,
+    education_zone_lka_only
 
 FROM vt
 

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_school_daily_troubleshooting.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_school_daily_troubleshooting.sql
@@ -1,0 +1,93 @@
+-- all_gigameter_school_daily_troubleshooting
+-- Purpose: pre-aggregated school+day summary feeding the Superset "T0 troubleshooting
+-- table" (dashboard.giga.global, dashboard 21, dataset 110). T0 currently runs 7
+-- separate CTEs, each independently scanning + filtering the full (unpartitioned,
+-- ~8.5M row) all_gigameter_measurement_data_incremental table on every dashboard
+-- render — this table lets T0 read from ~2.5M pre-aggregated rows instead, once.
+--
+-- One row per school per weekday. Full rebuild: drop and recreate (small table —
+-- schools x working days, same shape as all_gigameter_measurement_data_daily).
+--
+-- Deliberately separate from the in-progress device-grain all_gigameter_measurement_
+-- data_daily/_weekly rework (still "Testing" status, direction not yet locked) —
+-- this table is scoped narrowly to T0's needs and does not depend on that work.
+-- Sources from all_gigameter_measurement_data_incremental (not the plain
+-- all_gigameter_measurement_data table), matching T0's existing dependency — the
+-- incremental table has the geolocation columns (detected_location_is_flagged,
+-- detected_location_distance) that the plain daily/weekly tables' source lacks.
+--
+-- Column notes:
+--   min/max_app_version_numeric: semantic version encoded as int (e.g. "2.0.3" ->
+--     2000003) via the same SPLIT_PART formula T0 already uses, wrapped in a CASE
+--     (not a FILTER clause) so invalid strings become NULL before any CAST is
+--     attempted. T0's own CARDINALITY(SPLIT(...))=3 check only counts dot-separated
+--     parts, not that they're numeric -- some MLab-sourced rows have a non-numeric
+--     segment (e.g. "2.0.mlab") that still passes that check. A FILTER clause was
+--     tried first here and still errored (Trino evaluates the aggregate's argument
+--     expression before applying FILTER, at least for MIN_BY/MAX_BY's sort-key
+--     argument), hence the CASE-based rewrite -- confirmed clean across the full
+--     unfiltered 8.46M-row table before use here.
+--   min/max_app_version_str: the actual version string tied to that min/max via
+--     MIN_BY/MAX_BY, for display.
+--   location_flagged_count / max_location_distance_m: from detected_location_
+--     is_flagged / detected_location_distance (both NULL pre-app-v2.0.3).
+
+DROP TABLE IF EXISTS default.all_gigameter_school_daily_troubleshooting;
+
+CREATE TABLE default.all_gigameter_school_daily_troubleshooting
+WITH (
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_school_daily_troubleshooting'
+)
+AS (
+    SELECT
+        school_id_giga,
+        country,
+        date,
+
+        COUNT(*) AS measurement_count,
+
+        MIN(
+            CASE WHEN app_version IS NOT NULL AND app_version <> ''
+                  AND REGEXP_LIKE(app_version, '^[0-9]+\.[0-9]+\.[0-9]+$')
+                 THEN CAST(SPLIT_PART(app_version, '.', 1) AS INTEGER) * 1000000
+                    + CAST(SPLIT_PART(app_version, '.', 2) AS INTEGER) * 1000
+                    + CAST(SPLIT_PART(app_version, '.', 3) AS INTEGER)
+            END
+        ) AS min_app_version_numeric,
+
+        MIN_BY(
+            app_version,
+            CASE WHEN app_version IS NOT NULL AND app_version <> ''
+                  AND REGEXP_LIKE(app_version, '^[0-9]+\.[0-9]+\.[0-9]+$')
+                 THEN CAST(SPLIT_PART(app_version, '.', 1) AS INTEGER) * 1000000
+                    + CAST(SPLIT_PART(app_version, '.', 2) AS INTEGER) * 1000
+                    + CAST(SPLIT_PART(app_version, '.', 3) AS INTEGER)
+            END
+        ) AS min_app_version_str,
+
+        MAX(
+            CASE WHEN app_version IS NOT NULL AND app_version <> ''
+                  AND REGEXP_LIKE(app_version, '^[0-9]+\.[0-9]+\.[0-9]+$')
+                 THEN CAST(SPLIT_PART(app_version, '.', 1) AS INTEGER) * 1000000
+                    + CAST(SPLIT_PART(app_version, '.', 2) AS INTEGER) * 1000
+                    + CAST(SPLIT_PART(app_version, '.', 3) AS INTEGER)
+            END
+        ) AS max_app_version_numeric,
+
+        MAX_BY(
+            app_version,
+            CASE WHEN app_version IS NOT NULL AND app_version <> ''
+                  AND REGEXP_LIKE(app_version, '^[0-9]+\.[0-9]+\.[0-9]+$')
+                 THEN CAST(SPLIT_PART(app_version, '.', 1) AS INTEGER) * 1000000
+                    + CAST(SPLIT_PART(app_version, '.', 2) AS INTEGER) * 1000
+                    + CAST(SPLIT_PART(app_version, '.', 3) AS INTEGER)
+            END
+        ) AS max_app_version_str,
+
+        SUM(CASE WHEN detected_location_is_flagged = true THEN 1 ELSE 0 END) AS location_flagged_count,
+        MAX(detected_location_distance) AS max_location_distance_m
+
+    FROM default.all_gigameter_measurement_data_incremental
+    WHERE day_of_week(date) BETWEEN 1 AND 5
+    GROUP BY school_id_giga, country, date
+);

--- a/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
@@ -78,7 +78,13 @@ measurements_base AS (
         browser_id,
         device_hardware_id AS device_id,
         installed_path,
-        windows_username
+        windows_username,
+        -- Geolocation fields (available from app version 2.0.3+)
+        detected_latitude,
+        detected_longitude,
+        detected_location_is_flagged,
+        detected_location_distance,
+        detected_location_accuracy
     FROM
         gigameter_production_db.public.measurements
     WHERE
@@ -123,7 +129,12 @@ measurements_base AS (
       m.browser_id,
       m.device_id,
       m.installed_path,
-      m.windows_username
+      m.windows_username,
+      m.detected_latitude,
+      m.detected_longitude,
+      m.detected_location_is_flagged,
+      m.detected_location_distance,
+      m.detected_location_accuracy
   FROM
       measurements_base m
   LEFT JOIN
@@ -244,6 +255,15 @@ select
     -- -------------------------------------------------------------------------
     CAST(installed_path AS VARCHAR)                                                                  AS installed_path,
     CAST(windows_username AS VARCHAR)                                                                AS windows_username,
+
+    -- -------------------------------------------------------------------------
+    -- Geolocation (available from app version 2.0.3+)
+    -- -------------------------------------------------------------------------
+    CAST(detected_latitude AS DOUBLE)                                                                AS detected_latitude,
+    CAST(detected_longitude AS DOUBLE)                                                               AS detected_longitude,
+    CAST(detected_location_is_flagged AS BOOLEAN)                                                    AS detected_location_is_flagged,
+    CAST(detected_location_distance AS DOUBLE)                                                       AS detected_location_distance,
+    CAST(detected_location_accuracy AS DOUBLE)                                                       AS detected_location_accuracy,
 
     -- -------------------------------------------------------------------------
     -- Packet Loss Indicators (S2C - Server to Client)

--- a/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
@@ -86,7 +86,13 @@ measurements_base AS (
         browser_id,
         device_hardware_id AS device_id,
         installed_path,
-        windows_username
+        windows_username,
+        -- Geolocation fields (available from app version 2.0.3+)
+        detected_latitude,
+        detected_longitude,
+        detected_location_is_flagged,
+        detected_location_distance,
+        detected_location_accuracy
     FROM
         gigameter_production_db.public.measurements
     WHERE
@@ -139,7 +145,12 @@ SELECT
     m.browser_id,
     m.device_id,
     m.installed_path,
-    m.windows_username
+    m.windows_username,
+    m.detected_latitude,
+    m.detected_longitude,
+    m.detected_location_is_flagged,
+    m.detected_location_distance,
+    m.detected_location_accuracy
 FROM
     measurements_base m
 LEFT JOIN school_lookup s
@@ -261,6 +272,15 @@ select
     -- -------------------------------------------------------------------------
     CAST(installed_path AS VARCHAR) AS installed_path,
     CAST(windows_username AS VARCHAR) AS windows_username,
+
+    -- -------------------------------------------------------------------------
+    -- Geolocation (available from app version 2.0.3+)
+    -- -------------------------------------------------------------------------
+    CAST(detected_latitude AS DOUBLE)                                                                AS detected_latitude,
+    CAST(detected_longitude AS DOUBLE)                                                               AS detected_longitude,
+    CAST(detected_location_is_flagged AS BOOLEAN)                                                    AS detected_location_is_flagged,
+    CAST(detected_location_distance AS DOUBLE)                                                       AS detected_location_distance,
+    CAST(detected_location_accuracy AS DOUBLE)                                                       AS detected_location_accuracy,
 
 -- -------------------------------------------------------------------------
           -- Packet Loss Indicators (S2C - Server to Client)

--- a/dagster/src/queries/analytics_tables/daily/all_school_master.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_school_master.sql
@@ -13,8 +13,7 @@
 --
 -- Dependencies:
 --   - custom_dataset.school_master_all (primary source of school data)
---   - custom_dataset.country_geography (country names, regions, continents)
---   - gigamaps_production_db.public.locations_country (ISO3 country codes)
+--   - custom_dataset.country_geography (country names, ISO2/ISO3 codes, regions, continents)
 --   - default.country_versions (school master version tracking)
 --
 -- Output Columns:  69 columns
@@ -22,8 +21,10 @@
 -- Approximate Rows: ~2.1M schools (all countries)
 --
 -- CAVEATS:
---   - Some countries (TCA, NAM, SWZ, MNE, DJI, URY, AGO) require manual name
---     overrides because they are missing from the country_geography lookup
+--   - TCA (Turks and Caicos) requires a manual country-name override: the
+--     country_geography source value is 'Turks and Caicos ' (trailing space,
+--     no "Islands"). All other geography fields (region/continent/etc.) come
+--     straight from the country_geography lookup for every country.
 --   - connectivity vs connectivity_govt: 'connectivity' is Giga-standardized,
 --     'connectivity_govt' is original government-reported value
 --   - education_level vs education_level_govt: similar standardization applies
@@ -59,25 +60,21 @@ AS (
 
 -- ==============================================================================
 -- CTE: country_geography
--- Purpose: Builds a lookup table mapping ISO2 codes to country metadata
--- Source:  custom_dataset.country_geography (primary) + gigamaps locations
+-- Purpose: Lookup table mapping country codes to country metadata
+-- Source:  custom_dataset.country_geography — has both iso2_code (g.Code) and
+--          a native iso3_code column, so no bridging join is needed here
 -- Output:  Country name, ISO2/ISO3 codes, UNICEF region, ITU region, continent
--- Caveats: Some countries may be missing - handled via CASE statements in main query
 -- ==============================================================================
 WITH country_geography AS (
     SELECT
         g.Country,
         g.Code AS iso2_code,
-        lc.iso3_format AS iso3_code,
+        g.iso3_code,
         g.unicef_region,
         g.itu_region,
         g.continent
     FROM
         custom_dataset.country_geography g
-    LEFT JOIN
-        gigamaps_production_db.public.locations_country lc
-    ON
-        g.code = lc.code
 ),
 
 
@@ -106,55 +103,28 @@ versions AS (
 -- Purpose: Combines school data with geography and version info
 -- Source:  custom_dataset.school_master_all (consolidated school data)
 -- JOINs:
---   - LEFT JOIN country_geography: Adds regional classification (some countries missing)
+--   - LEFT JOIN country_geography: Adds regional classification
 --   - LEFT JOIN versions: Adds version tracking metadata
 -- ==============================================================================
 
 SELECT
     -- -------------------------------------------------------------------------
     -- Geographic Classification Fields
-    -- CAVEAT: Manual overrides for countries missing from country_geography
-    -- TCA = Turks and Caicos, NAM = Namibia, SWZ = Eswatini, MNE = Montenegro
-    -- DJI = Djibouti, URY = Uruguay, AGO = Angola
-    -- -------------------------------------------------------------------------
-    -- -------------------------------------------------------------------------
-    -- Geographic Classification Fields
-    -- CAVEAT: Manual overrides for countries missing from country_geography
-    -- TCA = Turks and Caicos, NAM = Namibia, SWZ = Eswatini, MNE = Montenegro
-    -- DJI = Djibouti, URY = Uruguay, AGO = Angola
+    -- CAVEAT: TCA's country_geography name is 'Turks and Caicos ' (trailing
+    -- space, no "Islands") — kept as a single manual override for display.
+    -- Every other country and every region/continent field comes straight
+    -- from the country_geography lookup.
     -- -------------------------------------------------------------------------
     CAST(CASE
         WHEN master.country = 'TCA' THEN 'Turks and Caicos Islands'
-        WHEN master.country = 'NAM' THEN 'Namibia'
-        WHEN master.country = 'SWZ' THEN 'Eswatini'
-        WHEN master.country = 'MNE' THEN 'Montenegro'
-        WHEN master.country = 'DJI' THEN 'Djibouti'
-        WHEN master.country = 'URY' THEN 'Uruguay'
-        WHEN master.country = 'AGO' THEN 'Angola'
-        WHEN master.country = 'ALB' THEN 'Albania'
         ELSE geo.country
-    END AS VARCHAR) AS country,             -- Full country name (with manual overrides)
+    END AS VARCHAR) AS country,             -- Full country name (TCA overridden for display)
 
-    CAST(CASE
-        WHEN master.country IN ('TCA', 'URY') THEN 'Latin America and Caribbean'
-        WHEN master.country IN ('NAM', 'SWZ', 'DJI', 'AGO') THEN 'Eastern and Southern Africa'
-        WHEN master.country IN ('MNE', 'ALB') THEN 'Eastern Europe and Central Asia'
-        ELSE geo.unicef_region
-    END AS VARCHAR) AS unicef_region,       -- UNICEF regional classification
+    CAST(geo.unicef_region AS VARCHAR) AS unicef_region,       -- UNICEF regional classification
 
-    CAST(CASE
-        WHEN master.country IN ('TCA', 'URY') THEN 'The Americas'
-        WHEN master.country IN ('NAM', 'SWZ', 'DJI', 'AGO') THEN 'Africa'
-        WHEN master.country IN ('MNE', 'ALB') THEN 'Europe'
-        ELSE geo.itu_region
-    END AS VARCHAR) AS itu_region,          -- ITU regional classification
+    CAST(geo.itu_region AS VARCHAR) AS itu_region,          -- ITU regional classification
 
-    CAST(CASE
-        WHEN master.country IN ('TCA', 'URY') THEN 'South America'
-        WHEN master.country IN ('NAM', 'SWZ', 'DJI', 'AGO') THEN 'Africa'
-        WHEN master.country IN ('MNE', 'ALB') THEN 'Europe'
-        ELSE geo.continent
-    END AS VARCHAR) AS continent,           -- Geographic continent
+    CAST(geo.continent AS VARCHAR) AS continent,           -- Geographic continent
 
     -- -------------------------------------------------------------------------
     -- School Identity Fields

--- a/dagster/src/queries/analytics_tables/daily/bra_benchmarkstatus_wow.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_benchmarkstatus_wow.sql
@@ -18,14 +18,14 @@
 --   connectivity performance over time.
 --
 -- Dependencies:
---   - default.bra_nicbr_daily_tb (daily NIC.BR measurements with benchmark flags)
+--   - default.bra_nicbr_daily (daily NIC.BR measurements with benchmark flags)
 --
 -- Output Columns:  ~20 columns
 -- Primary Key:     week (ISO week start date, Monday)
 -- Granularity:     One row per week, ordered most recent first
 --
 -- Run Notes:
---   Recurring — refresh weekly after bra_nicbr_daily_tb is updated.
+--   Recurring — refresh weekly after bra_nicbr_daily is updated.
 --   wow_change_* columns show absolute change vs the prior week;
 --   wow_change_percentage_* shows percentage change vs the prior week.
 --
@@ -43,7 +43,7 @@ WITH
   vt AS (
    SELECT *
    FROM
-     default.bra_nicbr_daily_tb
+     default.bra_nicbr_daily
    ORDER BY date ASC
 )
 , weekly_data_per_school AS (

--- a/dagster/src/queries/analytics_tables/daily/bra_nicbr_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_nicbr_daily.sql
@@ -1,9 +1,9 @@
 
 
 
- CREATE TABLE IF NOT EXISTS default.bra_nicbr_daily_tb
+ CREATE TABLE IF NOT EXISTS default.bra_nicbr_daily
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_daily_tb'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_daily'
 )
 as (
 

--- a/dagster/src/queries/analytics_tables/daily/bra_nicbr_registered_schools.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_nicbr_registered_schools.sql
@@ -1,7 +1,7 @@
 
 -- ==============================================================================
--- Script Name:     bra_nicbr_registered_tb.sql
--- Table Created:   default.bra_nicbr_registered_tb
+-- Script Name:     bra_nicbr_registered_schools.sql
+-- Table Created:   default.bra_nicbr_registered_schools
 -- Schema:          default
 -- Region:          Brazil
 -- Pipeline Status: Active (Integrated: true)
@@ -24,14 +24,14 @@
 --
 -- Run Notes:
 --   Recurring — refresh when NIC.BR data is updated. Upstream of
---   bra_nicbr_daily_tb.sql and bra_benchmarkstatus_wow.sql.
+--   bra_nicbr_daily.sql and bra_benchmarkstatus_wow.sql.
 --
 -- Last Updated:    2025-10-31 / Luke Stringer
 -- ==============================================================================
 
- CREATE TABLE IF NOT EXISTS default.bra_nicbr_registered_tb
+ CREATE TABLE IF NOT EXISTS default.bra_nicbr_registered_schools
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_registered_tb'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_registered_schools'
 )
 as (
 

--- a/dagster/src/queries/analytics_tables/daily/isp_asn_country_mapping.sql
+++ b/dagster/src/queries/analytics_tables/daily/isp_asn_country_mapping.sql
@@ -1,0 +1,259 @@
+-- ==============================================================================
+-- Script Name:     isp_asn_country_mapping.sql
+-- Table Created:   default.isp_asn_country_mapping
+-- Schema:          default
+-- Pipeline Status: Active
+--
+-- Purpose:
+--   Canonical ISP name/ASN lookup, one row per (country, raw ISP name, raw
+--   ASN) ever observed across GigaMeter and MLab measurements. Resolves
+--   ASN-truncation variants (e.g. a name reported under both a full ASN and
+--   a truncated prefix of it) to a single canonical ASN and display name per
+--   (country, ASN), and flags ASNs seen across >=3 countries as likely
+--   shared infrastructure (CDN/hosting) rather than a genuine local ISP.
+--   Joined back onto default.all_gigameter_measurement_data to produce
+--   isp_name_clean / isp_asn_clean / isp_key / is_likely_shared_infra.
+--
+-- Dependencies:
+--   - default.all_gmeter_only_measurements (GigaMeter raw ISP/ASN strings)
+--   - default.all_mlab_only_measurements (MLab raw ISP/ASN strings)
+--
+-- Output Columns:  13 columns
+-- Primary Key:     iso3_code + isp_name_raw + isp_asn_raw
+-- Granularity:     One row per (country, raw ISP name, raw ASN) combination
+--                  ever observed in either measurement source
+--
+-- CAVEATS:
+--   - ASN-truncation clustering resolves at most 2 hops deep (hop1 + one
+--     resolution pass) -- deliberately not a full recursive union-find,
+--     which blew Trino's stage limit at this CTE depth. No observed
+--     real-world case needs more than 2 hops.
+--   - Neighbour resolution is weighted by row_count, not string length --
+--     a longer ASN string doesn't always win (e.g. a Fiji case where
+--     AS14147 has far more rows than AS141470 for the same ISP).
+--   - name_display_norm's legal-suffix stripping list is deliberately
+--     generic (ltd/llc/inc/gmbh/... legal-form tokens only), not
+--     brand/company-specific -- extend it over time as needed.
+--   - is_likely_shared_infra is a heuristic (canonical_asn seen in >=3
+--     countries), not a maintained provider allowlist/blocklist.
+--   - built_at reflects when this table was last rebuilt, not when a given
+--     ISP/ASN combination was first observed.
+--
+-- Last Updated:    2026-07-30 / Luke Stringer
+-- ==============================================================================
+
+CREATE TABLE default.isp_asn_country_mapping
+WITH (
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/isp_asn_country_mapping'
+)
+AS (
+
+-- -----------------------------------------------------------------------
+-- CTE: raw_combos / combined
+-- Union step 1 + step 2, pre-aggregated to (country, raw name, raw asn).
+-- -----------------------------------------------------------------------
+WITH raw_combos AS (
+    SELECT iso3_code, MAX(country) AS country,
+           detected_isp_raw AS isp_name_raw, detected_isp_asn AS isp_asn_raw,
+           COUNT(*) AS row_count
+    FROM default.all_gmeter_only_measurements
+    GROUP BY iso3_code, detected_isp_raw, detected_isp_asn
+    UNION ALL
+    SELECT iso3_code, MAX(country) AS country,
+           detected_isp_raw AS isp_name_raw, detected_isp_asn AS isp_asn_raw,
+           COUNT(*) AS row_count
+    FROM default.all_mlab_only_measurements
+    GROUP BY iso3_code, detected_isp_raw, detected_isp_asn
+),
+combined AS (
+    SELECT iso3_code, MAX(country) AS country, isp_name_raw, isp_asn_raw,
+           SUM(row_count) AS row_count
+    FROM raw_combos
+    GROUP BY iso3_code, isp_name_raw, isp_asn_raw
+),
+
+-- -----------------------------------------------------------------------
+-- CTE: norm
+-- Generic normalization: strip embedded AS<digits> tokens from the name
+-- FIRST - some raw names embed the ASN, some don't, and skipping this
+-- step silently splits what should be one group - then extract a clean
+-- AS<digits> form for the ASN column.
+-- -----------------------------------------------------------------------
+norm AS (
+    SELECT
+        iso3_code, country, isp_name_raw, isp_asn_raw, row_count,
+        REGEXP_REPLACE(isp_name_raw, '(?i)AS\d{2,}', '') AS name_no_asn,
+        CASE WHEN REGEXP_EXTRACT(isp_asn_raw, '(\d+)', 1) IS NOT NULL
+             THEN 'AS' || REGEXP_EXTRACT(isp_asn_raw, '(\d+)', 1)
+             ELSE NULL END AS asn_norm
+    FROM combined
+),
+
+-- -----------------------------------------------------------------------
+-- CTE: norm2
+-- "Light" name normalization (case/quotes/whitespace only - NO legal-suffix
+-- stripping here). This is the grouping key for ASN clustering, matching
+-- the verified pattern of IDENTICAL name text across truncated ASN values.
+-- -----------------------------------------------------------------------
+norm2 AS (
+    SELECT iso3_code, country, isp_name_raw, isp_asn_raw, asn_norm, row_count,
+        TRIM(REGEXP_REPLACE(REGEXP_REPLACE(
+            LOWER(REPLACE(REPLACE(name_no_asn, '"', ''), '''', '')),
+            '[^a-z0-9]+', ' '), '\s+', ' ')) AS name_norm_light
+    FROM norm
+),
+
+-- -----------------------------------------------------------------------
+-- STAGE 1: ASN truncation clustering within (country, name_norm_light)
+-- -----------------------------------------------------------------------
+nodes AS (
+    SELECT iso3_code, name_norm_light, asn_norm, SUM(row_count) AS total_rows
+    FROM norm2
+    WHERE asn_norm IS NOT NULL AND name_norm_light <> ''
+    GROUP BY iso3_code, name_norm_light, asn_norm
+),
+edges AS (
+    -- a is a strict prefix of b, both non-null ASNs sharing the same
+    -- (country, name_norm_light) group
+    SELECT a.iso3_code, a.name_norm_light,
+           a.asn_norm AS asn_a, b.asn_norm AS asn_b,
+           a.total_rows AS rows_a, b.total_rows AS rows_b
+    FROM nodes a
+    JOIN nodes b
+      ON a.iso3_code = b.iso3_code
+     AND a.name_norm_light = b.name_norm_light
+     AND a.asn_norm <> b.asn_norm
+     AND LENGTH(a.asn_norm) < LENGTH(b.asn_norm)
+     AND b.asn_norm LIKE a.asn_norm || '%'
+),
+edges_undirected AS (
+    SELECT iso3_code, name_norm_light, asn_a AS asn_norm, asn_b AS nbr_asn, rows_b AS nbr_rows FROM edges
+    UNION ALL
+    SELECT iso3_code, name_norm_light, asn_b AS asn_norm, asn_a AS nbr_asn, rows_a AS nbr_rows FROM edges
+),
+best_neighbor AS (
+    SELECT iso3_code, name_norm_light, asn_norm, nbr_asn, nbr_rows,
+        ROW_NUMBER() OVER (
+            PARTITION BY iso3_code, name_norm_light, asn_norm
+            ORDER BY nbr_rows DESC, nbr_asn
+        ) AS rn
+    FROM edges_undirected
+),
+-- Pass 1: each node points to its highest-row-count prefix-neighbour,
+-- but ONLY if that neighbour actually has more rows (weighted-by-count,
+-- not "longer string always wins" - a real Fiji counter-example,
+-- AS14147 (16 rows) vs AS141470 (2 rows) for the same ISP, proves this
+-- matters - see header CAVEATS).
+hop1 AS (
+    SELECT n.iso3_code, n.name_norm_light, n.asn_norm, n.total_rows,
+        CASE WHEN bn.nbr_rows > n.total_rows THEN bn.nbr_asn ELSE n.asn_norm END AS target_asn
+    FROM nodes n
+    LEFT JOIN best_neighbor bn
+      ON bn.iso3_code = n.iso3_code AND bn.name_norm_light = n.name_norm_light
+     AND bn.asn_norm = n.asn_norm AND bn.rn = 1
+),
+-- Pass 2: resolve one further hop (safety net for a theoretical 2-link
+-- chain; not needed by any observed real-world case, deliberately NOT
+-- using WITH RECURSIVE - a full recursive union-find blew Trino's stage
+-- limit at this CTE depth - see header CAVEATS).
+asn_resolved AS (
+    SELECT h1.iso3_code, h1.name_norm_light, h1.asn_norm,
+        COALESCE(h1b.target_asn, h1.target_asn) AS canonical_asn
+    FROM hop1 h1
+    LEFT JOIN hop1 h1b
+      ON h1b.iso3_code = h1.iso3_code AND h1b.name_norm_light = h1.name_norm_light
+     AND h1b.asn_norm = h1.target_asn
+),
+
+-- -----------------------------------------------------------------------
+-- Attach resolved canonical_asn back onto every raw row (grain-preserving)
+-- -----------------------------------------------------------------------
+rows_with_canon_asn AS (
+    SELECT n2.iso3_code, n2.country, n2.isp_name_raw, n2.isp_asn_raw,
+           n2.row_count, n2.name_norm_light, n2.asn_norm,
+           COALESCE(ar.canonical_asn, n2.asn_norm) AS canonical_asn
+    FROM norm2 n2
+    LEFT JOIN asn_resolved ar
+      ON ar.iso3_code = n2.iso3_code AND ar.name_norm_light = n2.name_norm_light
+     AND ar.asn_norm = n2.asn_norm
+),
+
+-- -----------------------------------------------------------------------
+-- STAGE 2: pick a single canonical display name per (country, canonical_asn)
+-- "Display" normalization adds generic legal-entity-suffix stripping.
+-- Suffix list is deliberately generic (legal-form tokens only) - NOT
+-- brand/company-name-specific. Extend this list over time as needed;
+-- it never needs a specific ISP or country name added to it.
+-- -----------------------------------------------------------------------
+name_display_norm AS (
+    SELECT *,
+        TRIM(REGEXP_REPLACE(REGEXP_REPLACE(name_norm_light,
+            '(?i)\b(ltd|limited|llc|lcc|inc|incorporated|corp|corporation|plc|' ||
+            'gmbh|jsc|cjsc|ojsc|pjsc|pte|pty|sa|sas|ag|srl|bv|oy|ooo|doo|' ||
+            'd o o|d d|a d|b v|s a|s a s|' ||
+            'joint stock company|closed joint stock company|' ||
+            'open joint stock company|limited liability company)\b',
+            ''), '\s+', ' ')) AS name_norm_display
+    FROM rows_with_canon_asn
+),
+name_pick AS (
+    SELECT iso3_code, canonical_asn, name_norm_display, SUM(row_count) AS variant_rows
+    FROM name_display_norm
+    WHERE canonical_asn IS NOT NULL
+    GROUP BY iso3_code, canonical_asn, name_norm_display
+),
+canonical_names AS (
+    SELECT iso3_code, canonical_asn, name_norm_display AS canonical_isp_name,
+        ROW_NUMBER() OVER (
+            PARTITION BY iso3_code, canonical_asn
+            ORDER BY variant_rows DESC, name_norm_display
+        ) AS rn
+    FROM name_pick
+),
+canonical_names_final AS (
+    SELECT iso3_code, canonical_asn, canonical_isp_name
+    FROM canonical_names
+    WHERE rn = 1
+),
+
+-- -----------------------------------------------------------------------
+-- STAGE 3: shared-infrastructure signal, computed GLOBALLY (not per
+-- country) - distinct country count per resolved canonical_asn.
+-- Fully dynamic; no hardcoded hosting/CDN provider list.
+-- -----------------------------------------------------------------------
+asn_country_spread AS (
+    SELECT canonical_asn, COUNT(DISTINCT iso3_code) AS asn_distinct_country_count
+    FROM rows_with_canon_asn
+    WHERE canonical_asn IS NOT NULL
+    GROUP BY canonical_asn
+)
+
+-- -----------------------------------------------------------------------
+-- FINAL SELECT: one row per (country, isp_name_raw, isp_asn_raw) ever
+-- observed, enriched with resolved canonical columns.
+-- -----------------------------------------------------------------------
+SELECT
+    r.iso3_code,
+    r.country,
+    r.isp_name_raw,
+    r.isp_asn_raw,
+    r.row_count,
+    r.asn_norm,
+    r.canonical_asn,
+    COALESCE(cn.canonical_isp_name, r.name_norm_light, '(unknown)') AS canonical_isp_name,
+    TO_HEX(MD5(TO_UTF8(
+        r.iso3_code || '|' ||
+        COALESCE(cn.canonical_isp_name, r.name_norm_light, '(unknown)') || '|' ||
+        COALESCE(r.canonical_asn, 'NULL')
+    ))) AS isp_key,
+    (r.asn_norm IS NOT NULL AND r.canonical_asn IS NOT NULL
+        AND r.asn_norm <> r.canonical_asn) AS is_asn_truncation_merge,
+    COALESCE(acs.asn_distinct_country_count, 0) AS asn_distinct_country_count,
+    (COALESCE(acs.asn_distinct_country_count, 0) >= 3) AS is_likely_shared_infra,
+    CURRENT_TIMESTAMP AS built_at
+FROM rows_with_canon_asn r
+LEFT JOIN canonical_names_final cn
+  ON cn.iso3_code = r.iso3_code AND cn.canonical_asn = r.canonical_asn
+LEFT JOIN asn_country_spread acs
+  ON acs.canonical_asn = r.canonical_asn
+);

--- a/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_measurements.sql
@@ -16,7 +16,7 @@
 --
 -- Dependencies:
 --   - qos.mng (aggregated LibreRouter measurements for Mongolia)
---   - default.all_gigameter_measurement_data_tb_physical (GigaMeter daily data)
+--   - default.all_gigameter_measurement_data (GigaMeter daily data)
 --   - school_master.mng (Mongolia school master)
 --
 -- Output Columns:  ~25 columns
@@ -127,19 +127,19 @@ SELECT
 SELECT
   date,
   school_id_giga,
-  sum(num_measurements) as num_measurements,
+  count(*) as num_measurements,
   count(DISTINCT device_id) as num_devices,
-  avg(avg_download_speed) as avg_download_speed,
-  avg(avg_upload_speed) as avg_upload_speed,
-  avg(avg_latency) as avg_latency,
+  avg(download_speed) as avg_download_speed,
+  avg(upload_speed) as avg_upload_speed,
+  avg(latency) as avg_latency,
   max(detected_server) as detected_server,
-  max(isp_clean) as isp_clean,
-  max(isp_asn_clean) as isp_asn_clean,
+  max(isp_name) as isp_clean,
+  max(isp_asn) as isp_asn_clean,
   max(app_version) as app_version,
   1 as gigameter_source,
   'GigaMeter' as provider
 from
-  default.all_gigameter_measurement_data_tb_physical
+  default.all_gigameter_measurement_data
 where
   country = 'Mongolia'
 group by

--- a/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_registered.sql
+++ b/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_registered.sql
@@ -17,7 +17,16 @@
 --
 -- Dependencies:
 --   - qos_raw.mng (raw LibreRouter data for Mongolia)
---   - default.all_gigameter_registered_tb_physical (GigaMeter registered schools)
+--   - default.all_gigameter_registered_schools (GigaMeter registered schools --
+--     replaces all_gigameter_registered_tb_physical; primary/secondary server/isp/asn
+--     are derived here from its detected_*_nested map columns since it doesn't
+--     expose them as scalars)
+--   - default.all_gigameter_appversion_funnel (initial_registration_date -- not
+--     present on all_gigameter_registered_schools)
+--   - default.all_gigameter_measurement_data (num_measurements, num_days_measured,
+--     latest_measurement_app_version -- not present on all_gigameter_registered_schools)
+--   - gigameter_production_db.public.dailycheckapp_school (num_registration_attempts --
+--     not present on all_gigameter_registered_schools)
 --   - school_master.mng (Mongolia school master data)
 --
 -- Output Columns:  ~20 columns
@@ -84,33 +93,141 @@ libre AS (
 
 
 -- ==============================================================================
--- CTE: gigameter_registered
+-- CTE: gigameter_base
 -- Purpose: GigaMeter app registrations for Mongolia
--- Source:  default.all_gigameter_registered_tb_physical
--- Filter:  country = 'Mongolia' AND initial_registration_date IS NOT NULL
+-- Source:  default.all_gigameter_registered_schools
+-- Filter:  country = 'Mongolia' AND registered_gigameter = 'Yes'
+-- Note:    primary/secondary server/isp/asn derived from the detected_*_nested
+--          map columns (approx_most_frequent output, most-frequent-first) via
+--          the same element_at(map_keys(...), N) pattern
+--          all_gigameter_registered_tb_physical.sql used internally.
+-- ==============================================================================
+gigameter_base AS (
+    SELECT
+        school_id_giga,
+        first_measurement_date,
+        last_measurement_date,
+        max_app_version_gigameter AS highest_app_version_in_use,
+        element_at(map_keys(detected_server_nested), 1) AS primary_server,
+        element_at(map_keys(detected_server_nested), 2) AS secondary_server,
+        element_at(map_keys(detected_isp_nested), 1) AS primary_isp,
+        element_at(map_keys(detected_isp_nested), 2) AS secondary_isp,
+        element_at(map_keys(detected_isp_asn_nested), 1) AS primary_isp_asn,
+        element_at(map_keys(detected_isp_asn_nested), 2) AS secondary_isp_asn,
+        1 AS gigameter_source                   -- Flag for join logic
+    FROM default.all_gigameter_registered_schools
+    WHERE country = 'Mongolia'
+        AND registered_gigameter = 'Yes'
+),
+
+
+-- ==============================================================================
+-- CTE: gigameter_initial_registration
+-- Purpose: Initial registration date per school -- not present on
+--          all_gigameter_registered_schools, sourced directly from the funnel
+--          tracking table (same source all_gigameter_registered_tb_physical.sql
+--          used internally).
+-- Source:  default.all_gigameter_appversion_funnel
+-- ==============================================================================
+gigameter_initial_registration AS (
+    SELECT
+        school_id_giga,
+        MIN(initial_registration_date) AS initial_registration_date
+    FROM default.all_gigameter_appversion_funnel
+    WHERE country = 'Mongolia'
+    GROUP BY school_id_giga
+),
+
+
+-- ==============================================================================
+-- CTE: gigameter_measurement_stats
+-- Purpose: Measurement counts per school -- not present on
+--          all_gigameter_registered_schools, computed directly from raw
+--          measurement data (same approach
+--          all_gigameter_registered_tb_physical.sql used internally).
+-- Source:  default.all_gigameter_measurement_data
+-- ==============================================================================
+gigameter_measurement_stats AS (
+    SELECT
+        school_id_giga,
+        COUNT(DISTINCT local_created_timestamp) AS num_measurements,
+        COUNT(DISTINCT DATE_TRUNC('day', local_created_timestamp)) AS num_days_measured
+    FROM default.all_gigameter_measurement_data
+    WHERE country = 'Mongolia'
+    GROUP BY school_id_giga
+),
+
+
+-- ==============================================================================
+-- CTE: gigameter_latest_app_version
+-- Purpose: App version from each school's most recent measurement (distinct
+--          from highest_app_version_in_use, which is the highest version ever
+--          seen) -- not present on all_gigameter_registered_schools.
+-- Source:  default.all_gigameter_measurement_data
+-- ==============================================================================
+gigameter_latest_app_version AS (
+    SELECT school_id_giga, app_version AS latest_measurement_app_version
+    FROM (
+        SELECT
+            school_id_giga,
+            app_version,
+            ROW_NUMBER() OVER (PARTITION BY school_id_giga ORDER BY created_timestamp DESC) AS row_num
+        FROM default.all_gigameter_measurement_data
+        WHERE country = 'Mongolia'
+    ) ranked
+    WHERE row_num = 1
+),
+
+
+-- ==============================================================================
+-- CTE: gigameter_registration_attempts
+-- Purpose: Registration attempt counts per school -- not present on
+--          all_gigameter_registered_schools, computed directly from the raw
+--          registration events table (same approach
+--          all_gigameter_registered_tb_physical.sql used internally).
+-- Source:  gigameter_production_db.public.dailycheckapp_school
+-- ==============================================================================
+gigameter_registration_attempts AS (
+    SELECT
+        giga_id_school AS school_id_giga,
+        COUNT(DISTINCT created) AS num_registration_attempts
+    FROM gigameter_production_db.public.dailycheckapp_school
+    WHERE giga_id_school IN (SELECT school_id_giga FROM school_master.mng)
+    GROUP BY giga_id_school
+),
+
+
+-- ==============================================================================
+-- CTE: gigameter_registered
+-- Purpose: Recombines the CTEs above into the same shape the rest of this
+--          script expects (previously read directly, pre-joined, from
+--          all_gigameter_registered_tb_physical).
+-- Filter:  initial_registration_date IS NOT NULL (matches original semantics)
 -- ==============================================================================
 gigameter_registered AS (
     SELECT
-        school_id_giga,
-        initial_registration_date,
-        first_measurement_date,
-        last_measurement_date,
-        latest_measurement_app_version,
-        highest_app_version_in_use,
-        num_measurements,
-        num_days_measured,
-        num_registration_attempts,
-        primary_server,
-        primary_isp,
-        primary_isp_asn,
-        secondary_server,
-        secondary_isp,
-        secondary_isp_asn,
-        primary_source,
-        1 AS gigameter_source                   -- Flag for join logic
-    FROM default.all_gigameter_registered_tb_physical
-    WHERE country = 'Mongolia'
-        AND initial_registration_date IS NOT NULL
+        gb.school_id_giga,
+        gir.initial_registration_date,
+        gb.first_measurement_date,
+        gb.last_measurement_date,
+        glav.latest_measurement_app_version,
+        gb.highest_app_version_in_use,
+        gms.num_measurements,
+        gms.num_days_measured,
+        gra.num_registration_attempts,
+        gb.primary_server,
+        gb.primary_isp,
+        gb.primary_isp_asn,
+        gb.secondary_server,
+        gb.secondary_isp,
+        gb.secondary_isp_asn,
+        gb.gigameter_source
+    FROM gigameter_base gb
+    LEFT JOIN gigameter_initial_registration gir ON gb.school_id_giga = gir.school_id_giga
+    LEFT JOIN gigameter_measurement_stats gms ON gb.school_id_giga = gms.school_id_giga
+    LEFT JOIN gigameter_latest_app_version glav ON gb.school_id_giga = glav.school_id_giga
+    LEFT JOIN gigameter_registration_attempts gra ON gb.school_id_giga = gra.school_id_giga
+    WHERE gir.initial_registration_date IS NOT NULL
 ),
 
 

--- a/dagster/src/queries/analytics_tables/incremental/README.md
+++ b/dagster/src/queries/analytics_tables/incremental/README.md
@@ -1,49 +1,80 @@
 # Incremental Model Scripts
 
-Scripts executed on an **hourly cadence** via Dagster using an incremental insert pattern. Rather than recreating the full table on each run, these scripts append only new records — making them efficient for large, fast-growing tables.
+Scripts executed via Dagster using an incremental insert pattern. Rather than recreating the
+full table on each run, these scripts append only new records — making them efficient for
+large, fast-growing tables. Cadence varies by script — most run **hourly**, but
+`all_ping_daily_incremental` runs **daily** (see [Scripts](#scripts) below).
 
-Scripts are sourced from the **Incremental Models** NocoDB table (`ma6e34qsc3t11ah`).
+Scripts are maintained in [`unicef/giga-data-analytics`](https://github.com/unicef/giga-data-analytics/tree/main/analytics-tables/incremental) (itself sourced from the **Incremental Models** NocoDB table, `ma6e34qsc3t11ah`, with the exception of the two `all_ping_*_incremental` scripts, which don't yet have a NocoDB source record) and ported here via PR once validated there.
 
 ---
 
 ## How Incremental Models Work
 
-Each script:
-1. Reads from the production source tables
-2. Filters to only records newer than the latest timestamp already in the target table (with a 1-hour catch-up cap to handle backlog after failures)
-3. Deduplicates by `measurement_id` to prevent double-inserts
-4. **Inserts** new rows — does not drop or recreate the table
+The four measurement-pipeline scripts (Steps 1–4) are flat, per-row appends:
+1. Reads from the production source tables (or another already-incremental table)
+2. Filters to `id > (SELECT COALESCE(MAX(measurement_id), 0) FROM <own target table>)` — since
+   `measurement_id` is a guaranteed-unique, strictly-increasing integer, this single comparison
+   both selects new rows and guarantees no duplicates, with no separate dedup step needed.
+   Replaced a 3-part timestamp watermark + `NOT IN` dedup + future-date guard (2026-08-07) —
+   the old approach was more expensive (three subqueries against the growing target table
+   instead of one sargable comparison) and broke on table recreate/backfill, since it
+   bootstrapped from a hardcoded fallback date rather than "everything so far." Filtering out
+   source rows with corrupted future timestamps (a known data-quality issue — see
+   `gigameter_production_db.public.connectivity_ping_checks` and the raw `measurements` table)
+   is now handled separately, downstream in Dagster, not in these scripts.
+3. **Inserts** new rows — does not drop or recreate the table
 
-This pattern is fault-tolerant: if an hourly run fails, the next run automatically catches up the missed window.
+This pattern is fault-tolerant: if a run fails, the next run automatically catches up all
+rows with a higher id, however large the gap.
+
+`all_ping_daily_incremental` is also a flat append, but at a different (aggregated
+date+school+device) grain with no per-row id column to filter on — it still uses a
+date-based watermark (`local_created_date >= MAX(local_created_date)`) plus a composite-key
+`NOT EXISTS` anti-join for dedup. Not part of the id-based redesign above.
+
+`all_ping_hourly_incremental` is the one exception: it's a `GROUP BY` aggregation (one row per
+school+device+hour), not a flat per-row table, so a plain append can't correct an already-written
+bucket if a ping arrives late. It uses `MERGE INTO` instead of `INSERT INTO` — see the comment
+block at the top of `update/all_ping_hourly_incremental.sql` for the full reasoning (4-hour grace
+period + `connectivity_ids`-based reconciliation).
 
 ---
 
 ## Scripts
 
-| Script | Creates Table | Purpose | Depends On |
-|---|---|---|---|
-| `all_gmeter_only_measurements_incremental.sql` | `default.all_gmeter_only_measurements_incremental` | GigaMeter app raw measurements — incremental Step 1 | `gigameter_production_db` |
-| `all_mlab_only_measurements_incremental.sql` | `default.all_mlab_only_measurements_incremental` | MLab network test measurements — incremental Step 2 | `gigameter_production_db` |
-| `all_gigameter_valid_test_checker_incremental.sql` | `default.all_gigameter_valid_test_checker_incremental` | Per-measurement quality validation — incremental Step 3 | Steps 1 & 2 incremental |
-| `all_gigameter_measurement_data_incremental.sql` | `default.all_gigameter_measurement_data_incremental` | Consolidated validated measurements — incremental Step 4 | Steps 1, 2, & 3 incremental |
+| Script | Cadence | Creates Table | Purpose | Depends On |
+|---|---|---|---|---|
+| `all_gmeter_only_measurements_incremental.sql` | Hourly | `default.all_gmeter_only_measurements_incremental` | GigaMeter app raw measurements — incremental Step 1 | `gigameter_production_db` |
+| `all_mlab_only_measurements_incremental.sql` | Hourly | `default.all_mlab_only_measurements_incremental` | MLab network test measurements — incremental Step 2 | `gigameter_production_db` |
+| `all_gigameter_valid_test_checker_incremental.sql` | Hourly | `default.all_gigameter_valid_test_checker_incremental` | Per-measurement quality validation — incremental Step 3 | Steps 1 & 2 incremental |
+| `all_gigameter_measurement_data_incremental.sql` | Hourly | `default.all_gigameter_measurement_data_incremental` | Consolidated validated measurements — incremental Step 4 | Steps 1, 2, & 3 incremental |
+| `all_ping_hourly_incremental.sql` | Hourly | `default.all_ping_hourly_incremental` | Hourly ping/uptime aggregation per device-school (`MERGE`, not `INSERT` — see above) | `gigameter_production_db.connectivity_ping_checks` |
+| `all_ping_daily_incremental.sql` | Daily | `default.all_ping_daily_incremental` | Daily ping aggregation | `all_ping_hourly_incremental` |
 
-Run in order (Step 1 → 2 → 3 → 4); each step depends on the previous.
+Run each chain in order; each step depends on the previous within its own chain. The ping chain
+is independent of the measurement chain (Steps 1–4) — neither depends on the other.
 
 ---
 
 ## Execution Order
 
 ```
+Measurement chain (hourly):
 Step 1:  all_gmeter_only_measurements_incremental
 Step 2:  all_mlab_only_measurements_incremental
 Step 3:  all_gigameter_valid_test_checker_incremental
 Step 4:  all_gigameter_measurement_data_incremental
+
+Ping chain (mixed cadence):
+Step 1:  all_ping_hourly_incremental   (hourly)
+Step 2:  all_ping_daily_incremental    (daily — must run after that day's hourly buckets have settled)
 ```
 
 ---
 
 ## Relationship to Daily Scripts
 
-These scripts create **separate tables** (with `_incremental` suffix) that run in parallel with the existing daily equivalents in [`../daily/`](../daily/README.md) while validation is ongoing. Once confirmed working in production, the daily versions of Steps 1–4 will be retired.
+These scripts create **separate tables** (with `_incremental` suffix) that run in parallel with the existing daily equivalents in [`../daily/`](../daily/README.md) while validation is ongoing. Once confirmed working in production, the daily versions of Steps 1–4 and `all_ping_hourly` / `all_ping_daily` will be retired.
 
-A second iteration will extend incremental models to cover registration and regional scripts (`all_gigameter_registered_schools`, `all_gigameter_registered_devices`, `bra_nicbr_*`, `mng_gigameter_*`).
+Next up for conversion: `mng_gigameter_qos_measurements` and `bra_nicbr_daily` (daily aggregations, same pattern as the ping chain), then `all_gigameter_registered_schools` and `all_gigameter_registered_devices` — those two are full school/device-state snapshots rather than append-only event aggregations, so they'll need a different conversion approach, not a direct copy of this pattern.

--- a/dagster/src/queries/analytics_tables/incremental/create/all_gigameter_measurement_data_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_gigameter_measurement_data_incremental.sql
@@ -2,7 +2,8 @@
 CREATE TABLE  delta_lake.default.all_gigameter_measurement_data_incremental
 
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data_incremental'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data_incremental',
+    partitioned_by = ARRAY['country']
 )
 AS
 
@@ -32,7 +33,7 @@ WITH  measure AS (
 
     -- =========================================================================
     -- PART 1: GigaMeter Measurements
-    -- Source: delta_lake.default.all_gmeter_only_measurements_incremental
+    -- Source: default.all_gmeter_only_measurements
     -- Join: school_id_giga (reliable, from GigaMeter app registration)
     -- =========================================================================
     SELECT
@@ -67,7 +68,7 @@ UNION ALL
 
     -- =========================================================================
     -- PART 2: MLAB Measurements
-    -- Source: delta_lake.default.all_mlab_only_measurements_incremental
+    -- Source: default.all_mlab_only_measurements
     -- Join: school_id_govt + iso3_code (requires country for disambiguation)
     --
     -- CAVEAT: MLAB matching is less reliable
@@ -165,6 +166,17 @@ SELECT
     CAST(m.ip_address AS VARCHAR) AS ip_address,
     CAST(m.app_version AS VARCHAR) AS app_version,
     CAST(m.notes AS VARCHAR) AS notes,
+
+    -- -------------------------------------------------------------------------
+    -- ISP/ASN Canonical Mapping
+    -- Resolves ASN-truncation variants of the same ISP to a single canonical
+    -- name/ASN per country, and flags likely shared infrastructure (CDN/hosting)
+    -- -- see analytics-tables/daily/isp_asn_country_mapping.sql
+    -- -------------------------------------------------------------------------
+    CAST(map.canonical_isp_name AS VARCHAR) AS isp_name_clean,
+    CAST(map.canonical_asn AS VARCHAR) AS isp_asn_clean,
+    CAST(map.isp_key AS VARCHAR) AS isp_key,
+    CAST(map.is_likely_shared_infra AS BOOLEAN) AS is_likely_shared_infra,
 
     -- -------------------------------------------------------------------------
     -- WiFi Connection Details
@@ -275,6 +287,7 @@ SELECT
     CAST(c.canton_name AS VARCHAR) AS canton_bih_only,    -- Bosnia and Herzegovina only
     CAST(cc.status AS VARCHAR) AS connectivity_credits_school,  -- Connectivity credits pilot program
     CAST(p.zaf_province AS VARCHAR) AS province_zaf_only,
+    CAST(l.zone AS VARCHAR) as education_zone_lka_only,
 
     -- -------------------------------------------------------------------------
     -- Measurement Protocol
@@ -313,6 +326,11 @@ LEFT JOIN
   delta_lake.default.all_gigameter_valid_test_checker_incremental  mf
 on
   m.measurement_id = mf.measurement_id
+-- JOIN: ISP/ASN canonical mapping -- see isp_asn_country_mapping.sql
+LEFT JOIN default.isp_asn_country_mapping map
+  ON  map.iso3_code    = m.iso3_code
+  AND map.isp_name_raw = m.detected_isp_raw
+  AND map.isp_asn_raw  = m.detected_isp_asn
 -- JOIN: Bosnia canton mapping (country-specific enrichment)
 -- Only populates for schools in Bosnia and Herzegovina
 LEFT JOIN lstringer.bih_school_canton_mapping_vw c
@@ -325,3 +343,7 @@ LEFT JOIN lstringer.connectivity_credit_pilot_schools cc
 
 LEFT JOIN lstringer.zaf_province_mapping p
   on m.school_id_giga = p.school_id_giga
+
+LEFT JOIN lstringer.lka_school_education_zones l 
+  on m.school_id_govt = l.school_id_govt 
+  and m.iso3_code = l.iso3_code

--- a/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
@@ -84,8 +84,6 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'DailyCheckApp'  -- GigaMeter app measurements only
-    ORDER BY id
-    LIMIT 40000
 
 )
 
@@ -325,3 +323,5 @@ select
 
 FROM
   measurements_enriched
+
+   )

--- a/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
@@ -96,8 +96,6 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'MLab'  -- MLAB measurements only
-    ORDER BY id
-    LIMIT 40000
 )
 
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_daily_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_daily_incremental.sql
@@ -1,0 +1,139 @@
+
+CREATE TABLE delta_lake.default.all_ping_daily_incremental
+WITH (
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily_incremental'
+)
+AS (
+
+
+-- =============================================================================
+-- CTE: ping_daily
+-- Purpose: Roll all_ping_hourly_incremental up from device-school-hour to
+-- device-school-DAY. Full historical build -- no date cap, reads everything
+-- currently in the hourly incremental table.
+--
+-- Time-window split logic:
+--   Each row in all_ping_hourly_incremental has a single local_hour value (0-23).
+--   ALL ping_records in a row with local_hour=9 are hour-9 pings (school hours).
+--   ALL ping_records in a row with local_hour=22 are off-hours pings.
+--   Therefore CASE WHEN local_hour BETWEEN 8 AND 19 THEN ping_records gives the
+--   exact count of pings in that window -- no ambiguity, no approximation.
+--
+-- Latency:
+--   latency_ping in all_ping_hourly_incremental is AVG(latency) per hour. A plain
+--   AVG across hours would be an average-of-averages, wrong when hours have
+--   different counts. Weighted average: SUM(latency * ping_records) / SUM(ping_records)
+--   is correct.
+-- =============================================================================
+WITH ping_daily AS (
+    SELECT
+        local_created_date,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin1,
+        admin2,
+        device_id,
+
+        -- Total pings for the day
+        SUM(ping_records) AS ping_records,
+
+        -- Weighted average latency across all hours
+        SUM(latency_ping * ping_records) / NULLIF(SUM(ping_records), 0) AS avg_latency,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN ping_records ELSE 0 END)                              AS pings_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN is_connected_true ELSE 0 END)                         AS connected_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN ping_records - is_connected_true ELSE 0 END)          AS not_connected_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN ping_records ELSE 0 END)                              AS invalid_ping_9pm_to_7am_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN is_connected_true ELSE 0 END)                         AS connected_9pm_to_7am_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN ping_records - is_connected_true ELSE 0 END)          AS not_connected_9pm_to_7am_local,
+
+        -- Overall daily uptime: total connected / total pings
+        SUM(is_connected_true)
+            / NULLIF(CAST(SUM(ping_records) AS DECIMAL(10,2)), 0)           AS uptime,
+
+        -- School-hours uptime: connected during 8am-8pm / total pings during 8am-8pm
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19 THEN is_connected_true ELSE 0 END)
+            / NULLIF(CAST(
+                SUM(CASE WHEN local_hour BETWEEN 8 AND 19 THEN ping_records ELSE 0 END)
+              AS DECIMAL(10,2)), 0)                                          AS uptime_8am_to_8pm_local
+
+    FROM delta_lake.default.all_ping_hourly_incremental
+    GROUP BY
+        local_created_date,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin1,
+        admin2,
+        device_id
+),
+
+
+-- =============================================================================
+-- CTE: first_ping_recorded
+-- Purpose: Earliest ping date per school. Used to exclude dates before a
+-- school's first ping.
+-- =============================================================================
+first_ping_recorded AS (
+    SELECT
+        school_id_giga,
+        MIN(local_created_date) AS first_ping_date
+    FROM ping_daily
+    GROUP BY school_id_giga
+)
+
+
+-- =============================================================================
+-- FINAL SELECT
+-- =============================================================================
+SELECT
+    CAST(p.local_created_date AS DATE)                          AS local_created_date,
+
+    -- Ping completeness (48 expected = 12 school hours x 4 pings/hour)
+    CAST(48 AS INTEGER)                                         AS expected_pings_per_day,
+    CAST(48 - COALESCE(p.pings_8am_to_8pm_local, 0) AS BIGINT) AS missing_pings,
+
+    -- Identifiers
+    CAST(p.device_id      AS VARCHAR)                           AS device_id,
+    CAST(p.school_id_govt AS VARCHAR)                           AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR)                           AS school_id_giga,
+    CAST(p.school_name    AS VARCHAR)                           AS school_name,
+    CAST(p.country        AS VARCHAR)                           AS country,
+    CAST(p.admin1         AS VARCHAR)                           AS admin1,
+    CAST(p.admin2         AS VARCHAR)                           AS admin2,
+
+    -- Ping totals
+    CAST(p.ping_records                   AS BIGINT)            AS ping_records,
+    CAST(p.pings_8am_to_8pm_local         AS BIGINT)            AS pings_8am_to_8pm_local,
+    CAST(p.connected_8am_to_8pm_local     AS BIGINT)            AS connected_8am_to_8pm_local,
+    CAST(p.not_connected_8am_to_8pm_local AS BIGINT)            AS not_connected_8am_to_8pm_local,
+    CAST(p.invalid_ping_9pm_to_7am_local  AS BIGINT)            AS invalid_ping_9pm_to_7am_local,
+    CAST(p.connected_9pm_to_7am_local     AS BIGINT)            AS connected_9pm_to_7am_local,
+    CAST(p.not_connected_9pm_to_7am_local AS BIGINT)            AS not_connected_9pm_to_7am_local,
+
+    -- Latency and uptime
+    CAST(p.avg_latency            AS DOUBLE)                    AS latency_ping,
+    CAST(p.uptime                 AS DOUBLE)                    AS uptime,
+    CAST(p.uptime_8am_to_8pm_local AS DOUBLE)                   AS uptime_8am_to_8pm_local
+
+FROM ping_daily p
+JOIN first_ping_recorded f
+    ON p.school_id_giga = f.school_id_giga
+WHERE p.local_created_date >= f.first_ping_date
+  AND p.local_created_date <= CURRENT_DATE
+
+)

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
@@ -1,0 +1,226 @@
+
+CREATE TABLE delta_lake.default.all_ping_hourly_incremental
+WITH (
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly_incremental'
+)
+AS (
+
+-- =============================================================================
+-- CTE: school_lookup
+-- Purpose: Creates a reusable lookup for school metadata with pre-computed timezone
+--
+-- Timezone Fallback Chain:
+--   1. Try timezone by ISO3 code (tz.timezone)
+--   2. Try timezone by country name (tz_name.timezone)
+--   3. Default to 'UTC'
+-- =============================================================================
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+
+
+-- =============================================================================
+-- CTE: ping_base
+-- Purpose: Extract raw ping connectivity checks
+--
+-- NO TIME FILTER: unlike the 90-day rolling window in the daily drop-and-recreate
+-- version (all_ping_hourly.sql), this initial build reads all available raw ping
+-- history so the incremental table starts with complete history, not a 90-day
+-- slice of it. The update/ script re-filters going forward from there.
+-- =============================================================================
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+)
+
+
+-- =============================================================================
+-- CTE: ping_enriched
+-- Purpose: Join raw pings to school metadata and compute the LOCAL timestamp
+--
+-- Computing local_ts here (rather than filtering ping_base on the raw UTC
+-- cpc.timestamp first) means any future watermark/window filter in the update/
+-- script can compare local-to-local against local_date_hour with no timezone
+-- skew to account for.
+-- =============================================================================
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+ )
+
+
+-- =============================================================================
+-- CTE: ping_aggr
+-- Purpose: Aggregate ping data by school-device-hour
+--
+-- connectivity_ids: the raw ping ids that fed into each bucket. Not part of the
+-- daily version's schema — kept here so the update/ script can detect pings
+-- that arrive late (after their bucket was already inserted) by comparing this
+-- array against what's already stored, and correct that bucket via MERGE.
+-- =============================================================================
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+-- =============================================================================
+-- FINAL SELECT
+-- Purpose: Output ping-only aggregated data with first ping validation
+-- =============================================================================
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+)

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_measurement_data_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_measurement_data_incremental.sql
@@ -34,10 +34,15 @@ WITH  measure AS (
       -- GigaMeter uses reliable giga_id for matching
       m1.school_id_giga = s1.school_id_giga
 
-      -- Duplicate protection
-      WHERE m1.measurement_id NOT IN (
-          SELECT measurement_id
-         FROM delta_lake.default.all_gmeter_only_measurements_incremental
+      -- Incremental watermark: id is strictly increasing, so this single
+      -- comparison selects new rows and guarantees no duplicates. Checked
+      -- against this table's OWN target (all_gigameter_measurement_data_incremental)
+      -- -- a prior version of this filter incorrectly checked m1 for
+      -- membership against the table m1 was itself selected FROM, which is
+      -- always true and filtered nothing.
+      WHERE m1.measurement_id > (
+          SELECT COALESCE(MAX(measurement_id), 0)
+         FROM delta_lake.default.all_gigameter_measurement_data_incremental
       )
 
 UNION ALL
@@ -77,12 +82,13 @@ UNION ALL
       m2.school_id_govt = s2.school_id_govt
     and
       m2.iso3_code = s2.iso3_code
-      -- Duplicate protection
-      WHERE m2.measurement_id NOT IN (
-          SELECT measurement_id
-         FROM delta_lake.default.all_mlab_only_measurements_incremental
+      -- Incremental watermark -- same fix as the GigaMeter branch above,
+      -- checked against this table's own target.
+      WHERE m2.measurement_id > (
+          SELECT COALESCE(MAX(measurement_id), 0)
+         FROM delta_lake.default.all_gigameter_measurement_data_incremental
       )
-    
+
 
 
 )
@@ -149,6 +155,17 @@ SELECT
     CAST(m.ip_address AS VARCHAR) AS ip_address,
     CAST(m.app_version AS VARCHAR) AS app_version,
     CAST(m.notes AS VARCHAR) AS notes,
+
+    -- -------------------------------------------------------------------------
+    -- ISP/ASN Canonical Mapping
+    -- Resolves ASN-truncation variants of the same ISP to a single canonical
+    -- name/ASN per country, and flags likely shared infrastructure (CDN/hosting)
+    -- -- see analytics-tables/daily/isp_asn_country_mapping.sql
+    -- -------------------------------------------------------------------------
+    CAST(map.canonical_isp_name AS VARCHAR) AS isp_name_clean,
+    CAST(map.canonical_asn AS VARCHAR) AS isp_asn_clean,
+    CAST(map.isp_key AS VARCHAR) AS isp_key,
+    CAST(map.is_likely_shared_infra AS BOOLEAN) AS is_likely_shared_infra,
 
     -- -------------------------------------------------------------------------
     -- WiFi Connection Details
@@ -259,6 +276,7 @@ SELECT
     CAST(c.canton_name AS VARCHAR) AS canton_bih_only,    -- Bosnia and Herzegovina only
     CAST(cc.status AS VARCHAR) AS connectivity_credits_school,  -- Connectivity credits pilot program
     CAST(p.zaf_province AS VARCHAR) AS province_zaf_only,
+    CAST(l.zone AS VARCHAR) as education_zone_lka_only,
 
     -- -------------------------------------------------------------------------
     -- Measurement Protocol
@@ -297,6 +315,11 @@ LEFT JOIN
   delta_lake.default.all_gigameter_valid_test_checker_incremental  mf
 on
   m.measurement_id = mf.measurement_id
+-- JOIN: ISP/ASN canonical mapping -- see isp_asn_country_mapping.sql
+LEFT JOIN default.isp_asn_country_mapping map
+  ON  map.iso3_code    = m.iso3_code
+  AND map.isp_name_raw = m.detected_isp_raw
+  AND map.isp_asn_raw  = m.detected_isp_asn
 -- JOIN: Bosnia canton mapping (country-specific enrichment)
 -- Only populates for schools in Bosnia and Herzegovina
 LEFT JOIN lstringer.bih_school_canton_mapping_vw c
@@ -310,4 +333,7 @@ LEFT JOIN lstringer.connectivity_credit_pilot_schools cc
 LEFT JOIN lstringer.zaf_province_mapping p
   on m.school_id_giga = p.school_id_giga
 
+LEFT JOIN lstringer.lka_school_education_zones l 
+  on m.school_id_govt = l.school_id_govt 
+  and m.iso3_code = l.iso3_code
  

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_valid_test_checker_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_valid_test_checker_incremental.sql
@@ -11,15 +11,17 @@ INSERT INTO delta_lake.default.all_gigameter_valid_test_checker_incremental
 -- ============================================================
 WITH data AS (
   SELECT m1.* FROM delta_lake.default.all_gmeter_only_measurements_incremental  m1
-  -- ID FILTERING
-  WHERE m1.measurement_id NOT IN (
-    SELECT measurement_id FROM delta_lake.default.all_gigameter_valid_test_checker_incremental
+  -- ID FILTERING: measurement_id is strictly increasing, so this single
+  -- comparison selects new rows and guarantees no duplicates -- cheaper and
+  -- more scalable than NOT IN (a full anti-join against a growing table)
+  WHERE m1.measurement_id > (
+    SELECT COALESCE(MAX(measurement_id), 0) FROM delta_lake.default.all_gigameter_valid_test_checker_incremental
   )
   UNION ALL
   SELECT m2.* FROM delta_lake.default.all_mlab_only_measurements_incremental m2
   -- ID FILTERING
-  WHERE m2.measurement_id NOT IN (
-    SELECT measurement_id FROM delta_lake.default.all_gigameter_valid_test_checker_incremental
+  WHERE m2.measurement_id > (
+    SELECT COALESCE(MAX(measurement_id), 0) FROM delta_lake.default.all_gigameter_valid_test_checker_incremental
   )
 ),
 
@@ -285,3 +287,4 @@ SELECT
   ), '') AS VARCHAR) AS reasons_failed_upload
 
 FROM pf
+

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_valid_test_checker_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gigameter_valid_test_checker_incremental.sql
@@ -287,4 +287,3 @@ SELECT
   ), '') AS VARCHAR) AS reasons_failed_upload
 
 FROM pf
-

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
@@ -82,27 +82,16 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'DailyCheckApp'  -- GigaMeter app measurements only
-        
-      AND created_at >= (
-          SELECT COALESCE(
-              MAX(created_timestamp),
-              TIMESTAMP '2022-01-01 00:00:00 UTC'
-          )
+        -- Incremental watermark: id is a guaranteed-unique, strictly-increasing
+        -- integer, so this single comparison both selects new rows and
+        -- guarantees no duplicates -- replaces the old 3-part timestamp
+        -- watermark + NOT IN dedup + future-date guard (expensive, and broke
+        -- on table recreate/backfill). Future-dated source rows are now
+        -- filtered separately, downstream in Dagster.
+      AND id > (
+          SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_gmeter_only_measurements_incremental
       )
-      -- Duplicate protection
-      AND id NOT IN (
-          SELECT measurement_id
-         FROM delta_lake.default.all_gmeter_only_measurements_incremental
-      )
-    -- future dates protection
-      AND created_at < (
-          SELECT
-              date_add('hour', 1, MAX(created_timestamp))
-         FROM delta_lake.default.all_gmeter_only_measurements_incremental
-      )
-    ORDER BY id
-    LIMIT 40000
 
 )
 

--- a/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
@@ -93,28 +93,16 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'MLab'  -- MLAB measurements only
-      -- Incremental watermark
-      -- pre-launch date protection
-      AND created_at >= (
-          SELECT COALESCE(
-              MAX(created_timestamp),
-              TIMESTAMP '2022-01-01 00:00:00 UTC'
-          )
+        -- Incremental watermark: id is a guaranteed-unique, strictly-increasing
+        -- integer, so this single comparison both selects new rows and
+        -- guarantees no duplicates -- replaces the old 3-part timestamp
+        -- watermark + NOT IN dedup + future-date guard (expensive, and broke
+        -- on table recreate/backfill). Future-dated source rows are now
+        -- filtered separately, downstream in Dagster.
+      AND id > (
+          SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_mlab_only_measurements_incremental
       )
-      -- Duplicate protection
-      AND id NOT IN (
-          SELECT measurement_id
-         FROM delta_lake.default.all_mlab_only_measurements_incremental
-      )
-    -- future dates protection
-      AND created_at < (
-          SELECT
-              date_add('hour', 1, MAX(created_timestamp))
-         FROM delta_lake.default.all_mlab_only_measurements_incremental
-      )
-    ORDER BY id
-    LIMIT 40000
 )
 
 

--- a/dagster/src/queries/analytics_tables/incremental/update/all_ping_daily_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_ping_daily_incremental.sql
@@ -1,0 +1,140 @@
+
+-- =============================================================================
+-- Forward-only watermark + composite-key dedup, not MERGE
+--
+-- Unlike all_ping_hourly_incremental, this table doesn't need the MERGE/
+-- reconciliation treatment: a day is only ever rolled up once it's fully in the
+-- past (local_created_date < CURRENT_DATE), which is a much larger natural
+-- buffer than the hourly script's 4-hour grace period, and any hourly-bucket
+-- correction that landed within that buffer is already reflected in
+-- all_ping_hourly_incremental by the time this runs. Plain INSERT + anti-join
+-- dedup is enough here.
+-- =============================================================================
+
+INSERT INTO delta_lake.default.all_ping_daily_incremental
+
+
+-- =============================================================================
+-- CTE: ping_daily
+-- Purpose: Roll all_ping_hourly_incremental up from device-school-hour to
+-- device-school-DAY, for days not yet in the target table.
+--
+-- Watermark: local_created_date >= MAX(local_created_date) already in the
+-- target -- forward-only, no rolling cap, so no historical data is ever
+-- dropped. The >= (not >) deliberately overlaps the last-inserted date, since
+-- some schools' hourly data for that day may have settled after the previous
+-- run; the anti-join dedup below handles the resulting overlap safely.
+-- =============================================================================
+WITH ping_daily AS (
+    SELECT
+        local_created_date,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin1,
+        admin2,
+        device_id,
+
+        SUM(ping_records) AS ping_records,
+
+        SUM(latency_ping * ping_records) / NULLIF(SUM(ping_records), 0) AS avg_latency,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN ping_records ELSE 0 END)                              AS pings_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN is_connected_true ELSE 0 END)                         AS connected_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19
+                 THEN ping_records - is_connected_true ELSE 0 END)          AS not_connected_8am_to_8pm_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN ping_records ELSE 0 END)                              AS invalid_ping_9pm_to_7am_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN is_connected_true ELSE 0 END)                         AS connected_9pm_to_7am_local,
+
+        SUM(CASE WHEN local_hour NOT BETWEEN 8 AND 19
+                 THEN ping_records - is_connected_true ELSE 0 END)          AS not_connected_9pm_to_7am_local,
+
+        SUM(is_connected_true)
+            / NULLIF(CAST(SUM(ping_records) AS DECIMAL(10,2)), 0)           AS uptime,
+
+        SUM(CASE WHEN local_hour BETWEEN 8 AND 19 THEN is_connected_true ELSE 0 END)
+            / NULLIF(CAST(
+                SUM(CASE WHEN local_hour BETWEEN 8 AND 19 THEN ping_records ELSE 0 END)
+              AS DECIMAL(10,2)), 0)                                          AS uptime_8am_to_8pm_local
+
+    FROM delta_lake.default.all_ping_hourly_incremental
+    WHERE
+        local_created_date >= (
+            SELECT COALESCE(MAX(local_created_date), DATE '2022-01-01')
+            FROM delta_lake.default.all_ping_daily_incremental
+        )
+        -- Only fully-complete days -- today is still accumulating hourly buckets
+        AND local_created_date < CURRENT_DATE
+    GROUP BY
+        local_created_date,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin1,
+        admin2,
+        device_id
+),
+
+
+first_ping_recorded AS (
+    SELECT
+        school_id_giga,
+        MIN(local_created_date) AS first_ping_date
+    FROM ping_daily
+    GROUP BY school_id_giga
+)
+
+
+-- =============================================================================
+-- FINAL SELECT
+-- =============================================================================
+SELECT
+    CAST(p.local_created_date AS DATE)                          AS local_created_date,
+
+    CAST(48 AS INTEGER)                                         AS expected_pings_per_day,
+    CAST(48 - COALESCE(p.pings_8am_to_8pm_local, 0) AS BIGINT) AS missing_pings,
+
+    CAST(p.device_id      AS VARCHAR)                           AS device_id,
+    CAST(p.school_id_govt AS VARCHAR)                           AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR)                           AS school_id_giga,
+    CAST(p.school_name    AS VARCHAR)                           AS school_name,
+    CAST(p.country        AS VARCHAR)                           AS country,
+    CAST(p.admin1         AS VARCHAR)                           AS admin1,
+    CAST(p.admin2         AS VARCHAR)                           AS admin2,
+
+    CAST(p.ping_records                   AS BIGINT)            AS ping_records,
+    CAST(p.pings_8am_to_8pm_local         AS BIGINT)            AS pings_8am_to_8pm_local,
+    CAST(p.connected_8am_to_8pm_local     AS BIGINT)            AS connected_8am_to_8pm_local,
+    CAST(p.not_connected_8am_to_8pm_local AS BIGINT)            AS not_connected_8am_to_8pm_local,
+    CAST(p.invalid_ping_9pm_to_7am_local  AS BIGINT)            AS invalid_ping_9pm_to_7am_local,
+    CAST(p.connected_9pm_to_7am_local     AS BIGINT)            AS connected_9pm_to_7am_local,
+    CAST(p.not_connected_9pm_to_7am_local AS BIGINT)            AS not_connected_9pm_to_7am_local,
+
+    CAST(p.avg_latency            AS DOUBLE)                    AS latency_ping,
+    CAST(p.uptime                 AS DOUBLE)                    AS uptime,
+    CAST(p.uptime_8am_to_8pm_local AS DOUBLE)                   AS uptime_8am_to_8pm_local
+
+FROM ping_daily p
+JOIN first_ping_recorded f
+    ON p.school_id_giga = f.school_id_giga
+WHERE p.local_created_date >= f.first_ping_date
+  AND p.local_created_date <= CURRENT_DATE
+  -- Dedup: skip any (date, school, device) already present -- guards the
+  -- boundary day the watermark deliberately overlaps
+  AND NOT EXISTS (
+      SELECT 1
+      FROM delta_lake.default.all_ping_daily_incremental t
+      WHERE t.local_created_date = CAST(p.local_created_date AS DATE)
+        AND t.school_id_giga = CAST(p.school_id_giga AS VARCHAR)
+        AND t.device_id = CAST(p.device_id AS VARCHAR)
+  )

--- a/dagster/src/queries/analytics_tables/incremental/update/all_ping_hourly_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_ping_hourly_incremental.sql
@@ -1,0 +1,286 @@
+
+-- =============================================================================
+-- MERGE, not INSERT
+--
+-- This table is a GROUP BY aggregation (one row per school+device+hour), unlike
+-- the other 4 incremental scripts which are flat, per-measurement rows. A plain
+-- INSERT can't safely correct an already-written bucket without duplicating its
+-- key and double-counting downstream (all_ping_daily_incremental sums
+-- ping_records by day off this table) -- so late-arriving pings are handled via
+-- MERGE: insert new (settled) buckets, replace a bucket in place if reconciliation
+-- finds its raw ping ids changed since it was last written.
+--
+-- Two safeguards against losing/missing pings near an hour boundary:
+--   1. 4-hour grace period -- a bucket is only INSERTed once local_date_hour is
+--      at least 4 hours old, giving most stragglers time to land in the source
+--      table before that bucket is ever finalized.
+--   2. connectivity_ids reconciliation -- every run re-aggregates a 48h trailing
+--      window and compares each bucket's freshly computed connectivity_ids
+--      against what's already stored. Any bucket whose id set grew (a genuinely
+--      late ping, past the grace period) gets its whole row replaced with the
+--      corrected aggregate.
+-- =============================================================================
+
+MERGE INTO delta_lake.default.all_ping_hourly_incremental AS target
+USING (
+
+
+-- =============================================================================
+-- CTE: school_lookup
+-- Purpose: Creates a reusable lookup for school metadata with pre-computed timezone
+-- =============================================================================
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+
+
+-- =============================================================================
+-- CTE: ping_base
+-- Purpose: Extract raw ping connectivity checks
+--
+-- WHERE clause here is a coarse, partition-friendly PERFORMANCE pre-filter on
+-- the raw UTC timestamp only -- deliberately wider (72h) than the 48h
+-- reconciliation window below, to safely absorb the local-time <-> UTC offset
+-- (up to ~14h) without risking clipping a row before the precise filter in
+-- ping_enriched gets to see it. This is NOT the correctness boundary.
+-- =============================================================================
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= (
+          SELECT COALESCE(MAX(local_date_hour), TIMESTAMP '2022-01-01 00:00:00')
+          FROM delta_lake.default.all_ping_hourly_incremental
+      ) - INTERVAL '72' HOUR
+)
+
+
+-- =============================================================================
+-- CTE: ping_enriched
+-- Purpose: Join raw pings to school metadata, compute local_ts, and apply the
+-- PRECISE reconciliation window filter -- local-to-local, so no timezone buffer
+-- is needed here (unlike the coarse raw-UTC pre-filter in ping_base above).
+-- =============================================================================
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= (
+      SELECT COALESCE(MAX(local_date_hour), TIMESTAMP '2022-01-01 00:00:00')
+      FROM delta_lake.default.all_ping_hourly_incremental
+  ) - INTERVAL '48' HOUR
+
+ )
+
+
+-- =============================================================================
+-- CTE: ping_aggr
+-- Purpose: Aggregate ping data by school-device-hour, same as create/
+-- =============================================================================
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+        -- Carried through so the grace period below can be evaluated in each
+        -- school's own local time, not the session's UTC "now"
+        timezone,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Sorted for stable equality comparison against target.connectivity_ids
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+        timezone
+
+)
+
+
+-- =============================================================================
+-- FINAL SELECT (this becomes the MERGE's `source`)
+-- =============================================================================
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    p.connectivity_ids,
+
+    -- Control column for the MERGE's grace-period check below -- NOT part of the
+    -- target table, excluded from the INSERT column list. Evaluated in the
+    -- school's own local time (via p.timezone), not session "now", for the same
+    -- reason the reconciliation window above compares local-to-local.
+    CAST(
+        p.local_date_hour <= CAST(at_timezone(current_timestamp, p.timezone) AS TIMESTAMP) - INTERVAL '4' HOUR
+    AS BOOLEAN) AS is_settled
+
+FROM
+  ping_aggr p
+
+
+) AS source
+ON
+    target.local_date_hour = source.local_date_hour
+    AND target.school_id_giga = source.school_id_giga
+    AND target.device_id = source.device_id
+
+-- Late-arriving pings: the bucket already exists but gained new raw ids since it
+-- was last written -- replace it with the corrected aggregate.
+WHEN MATCHED AND target.connectivity_ids != source.connectivity_ids THEN
+    UPDATE SET
+        local_created_date = source.local_created_date,
+        local_date_minus_1hr = source.local_date_minus_1hr,
+        local_hour = source.local_hour,
+        school_name = source.school_name,
+        country = source.country,
+        admin1 = source.admin1,
+        admin2 = source.admin2,
+        expected_pings_per_hour = source.expected_pings_per_hour,
+        missing_pings = source.missing_pings,
+        ping_records = source.ping_records,
+        is_connected_true = source.is_connected_true,
+        is_school_hours = source.is_school_hours,
+        latency_ping = source.latency_ping,
+        uptime = source.uptime,
+        availability = source.availability,
+        connectivity_ids = source.connectivity_ids
+
+-- New bucket, only once it's past the 4-hour grace period (buckets still inside
+-- the window are left for a later run rather than finalized early).
+WHEN NOT MATCHED AND source.is_settled THEN
+    INSERT (
+        local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+        device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+        expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+        is_school_hours, latency_ping, uptime, availability, connectivity_ids
+    )
+    VALUES (
+        source.local_created_date, source.local_date_hour, source.local_date_minus_1hr, source.local_hour,
+        source.device_id, source.school_id_govt, source.school_id_giga, source.school_name, source.country, source.admin1, source.admin2,
+        source.expected_pings_per_hour, source.missing_pings, source.ping_records, source.is_connected_true,
+        source.is_school_hours, source.latency_ping, source.uptime, source.availability, source.connectivity_ids
+    )


### PR DESCRIPTION
## Context

Per Slack discussion with Brian M and Luke (giga-baw8117.slack.com/archives/C093D3XUW9X/p1786091276315369): `giga-data-analytics` is the authoring/validation repo for these SQL scripts; this repo is the deployment copy Dagster actually executes. Luke: *"I should be able to have all the necessary tables added and scripts updated in the github repo [giga-data-analytics]. Then we will need to do a refresh of the scripts which sit in dagster."* This PR is that refresh.

`dagster/src/queries/analytics_tables` had drifted significantly from `giga-data-analytics/analytics-tables` — every shared script differed at minimum by the `location` clause convention, most had real content drift (missing recent feature work), 3 scripts had legacy names, and 6 scripts / 2 asset functions (the entire ping incremental chain) were missing outright.

## How this repo's scripts are wired (for context on the scope of changes)

Each `.sql` file has a matching `@asset`-decorated Python function in `dagster/src/assets/analytics_tables/assets.py`, named identically, with explicit `deps=[AssetKey(...)]` declarations forming the DAG. So this isn't a pure file copy — renames and additions both require Python changes too.

## Renamed (script + `@asset` function + every `deps=[]` reference updated)

- `all_gigameter_funnelsummary_tb_physical` → `all_gigameter_funnelsummary`
- `bra_nicbr_daily_tb` → `bra_nicbr_daily`
- `bra_nicbr_registered_tb` → `bra_nicbr_registered_schools`

## Added (new SQL + new `@asset` function, correct `deps=[]`)

- `isp_asn_country_mapping` (daily) — canonical ISP/ASN lookup
- `all_gigameter_school_daily_troubleshooting` (daily, depends on the incremental measurement_data table)
- `all_ping_hourly_incremental` / `all_ping_daily_incremental` (incremental, create + update) — this whole chain didn't exist in this repo's asset graph before

## Fixed `deps=[]` to match what the SQL actually reads now, not just synced content

- `all_gigameter_funnelsummary`: added `all_gmeter_only_measurements` / `all_mlab_only_measurements` — it dropped two legacy `_vw` views in favour of these tables
- `mng_gigameter_qos_measurements` / `mng_gigameter_qos_registered`: swapped the old `_tb_physical` deps for the modern `all_gigameter_measurement_data` / `all_gigameter_registered_schools` (+ `all_gigameter_appversion_funnel`) tables they read from now
- `all_gigameter_measurement_data` (daily + incremental): added `isp_asn_country_mapping`, which both now `LEFT JOIN`

## Content sync, preserving this repo's own conventions

Every other shared script's content synced from `giga-data-analytics`, but preserving this repo's `WITH (location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/<table>')` clause (which `giga-data-analytics`'s copies mostly omit — that repo relies on the `default` schema's own storage resolution). For the two partitioned tables, that meant adding `location` alongside the existing `partitioned_by`, not a second `WITH` clause. Incremental `create/` scripts use the same pattern with a literal `abfss://` URI over there — substituted in the `{AZURE_BLOB_CONNECTION_URI}` template to match this repo.

**`all_school_master.sql` needed actual investigation, not a blind sync**: this repo's version had 7 manual country-name overrides (TCA, NAM, SWZ, MNE, DJI, URY, AGO); `giga-data-analytics`'s current version only has one (TCA). Checked live in Trino — all 7 resolve cleanly via `custom_dataset.country_geography.iso3_code` today, confirming the other 6 were workarounds for a since-fixed broken ISO2/ISO3 join (`giga-data-analytics` PR #12, earlier this cycle) and are now redundant. Synced `giga-data-analytics`'s version.

## Explicitly excluded

- **`all_gigameter_measurement_data_daily.sql` / `_weekly.sql`**: `giga-data-analytics`'s copies are uncommitted local WIP (a percentile-metric rework, "Testing" status, direction not locked) never merged there either. Confirmed the two repos' actually-committed content already matches (location clause aside) — nothing to sync.
- **`testing/superset_session_lengths.sql`**: not asset-wired (non-pipeline script), and this repo's copy targets a different schema (`public` vs `default`) — looks like a deliberate environment-specific adaptation, not staleness. Left alone.
- **`views/school_connectivity_status_vw.sql`**: doesn't fit either the daily or incremental asset pattern (it's a view, not a rebuilt table). Per direction, left out of the Dagster asset graph entirely — needs manual one-time creation directly in Trino (see `giga-data-analytics`'s `analytics-tables/views/README.md` for the script and rationale).

## Validation

- `assets.py` parses cleanly (`ast.parse`)
- Every `AssetKey` referenced in a `deps=[]` list cross-checked programmatically against actually-defined assets — all resolve, no dangling references
- SQL content carries forward the live-Trino validation already done in `giga-data-analytics` PRs #15-20 (read-only Trino access there; nothing executed against this repo's Trino/Dagster environment in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)