### PR TITLE
chore: rename exact location columns

### DIFF
--- a/dagster/src/data_quality_checks/duplicates.py
+++ b/dagster/src/data_quality_checks/duplicates.py
@@ -67,6 +67,14 @@ def duplicate_set_checks(
             column_actions["dq_duplicate_location_rows_id"] = f.when(
                 null_coords, f.lit(None)
             ).otherwise(f.substring(f.md5(f.col("location_id")), 1, 8))
+            # Plain-named copies so these also survive the dq_ prefix collapse and reach master.
+            column_actions["duplicate_location_rows_flag"] = column_actions[flag_col]
+            column_actions["duplicate_location_rows_count"] = column_actions[
+                "dq_duplicate_location_rows_count"
+            ]
+            column_actions["duplicate_location_rows_ID"] = column_actions[
+                "dq_duplicate_location_rows_id"
+            ]
 
     df = df.withColumns(column_actions)
     return df.drop("location_id") if has_lat_long else df

--- a/dagster/src/data_quality_checks/utils.py
+++ b/dagster/src/data_quality_checks/utils.py
@@ -226,7 +226,7 @@ _DQR_WARNINGS_COLUMN = "DQR Warnings"
 
 def get_warning_check_labels() -> dict[str, str]:
     """dq_results keys flagged as report warnings in NocoDB (DQR Warnings == Yes),
-    mapped to their "Human Readable Name" label."""
+    mapped to their "UI Error Description" label."""
     table_id = get_nocodb_table_id_from_name(
         table_name="SchoolGeolocationMasterDQChecks"
     )
@@ -241,7 +241,7 @@ def get_warning_check_labels() -> dict[str, str]:
             col_name = col_name[len("dq_") :]
         if not col_name or col_name in METADATA_CHECK_KEYS:
             continue
-        label = str(row.get("Human Readable Name") or "").strip()
+        label = str(row.get("UI Error Description") or "").strip()
         labels[col_name] = label or col_name
     return labels
 

--- a/dagster/src/spark/config_expectations.py
+++ b/dagster/src/spark/config_expectations.py
@@ -194,6 +194,9 @@ class Config(BaseSettings):
         ("duplicate_group_flag_50", "INT"),
         ("duplicate_group_id_50", "INT"),
         ("duplicate_group_count_50", "INT"),
+        ("duplicate_location_rows_flag", "INT"),
+        ("duplicate_location_rows_count", "INT"),
+        ("duplicate_location_rows_ID", "STRING"),
         ("nearest_NR_id", "STRING"),
         ("nearest_LTE_id", "STRING"),
         ("nearest_UMTS_id", "STRING"),
@@ -599,6 +602,9 @@ class Config(BaseSettings):
         "duplicate_group_flag_50",
         "duplicate_group_id_50",
         "duplicate_group_count_50",
+        "duplicate_location_rows_flag",
+        "duplicate_location_rows_count",
+        "duplicate_location_rows_ID",
     ]
 
     COLUMNS_EXCEPT_SCHOOL_ID_MASTER: list[str] = [
@@ -625,6 +631,9 @@ class Config(BaseSettings):
         "duplicate_group_flag_50",
         "duplicate_group_id_50",
         "duplicate_group_count_50",
+        "duplicate_location_rows_flag",
+        "duplicate_location_rows_count",
+        "duplicate_location_rows_ID",
         "connectivity_govt_collection_year",
         "connectivity_govt",
         # "school_id_giga",


### PR DESCRIPTION
## What type of PR is this?

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)

## Summary

What does this PR do
renames the downstream exact location columns