### PR TITLE
refactor: partition analytics tables and restore incremental limit

### DIFF
--- a/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
@@ -2,9 +2,12 @@
 
 
 
-  CREATE TABLE IF NOT EXISTS default.all_gmeter_only_measurements
+-- DROP TABLE IF EXISTS default.all_gmeter_only_measurements;
+
+  CREATE TABLE default.all_gmeter_only_measurements
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements',
+    partitioned_by = ARRAY['country']
 )
 as (
 

--- a/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
@@ -1,9 +1,6 @@
 
 
 
-
--- DROP TABLE IF EXISTS default.all_gmeter_only_measurements;
-
   CREATE TABLE default.all_gmeter_only_measurements
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements',

--- a/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
@@ -1,7 +1,10 @@
 
- CREATE TABLE IF NOT EXISTS default.all_mlab_only_measurements
+-- DROP TABLE IF EXISTS default.all_mlab_only_measurements;
+
+ CREATE TABLE default.all_mlab_only_measurements
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements',
+    partitioned_by = ARRAY['country']
 )
 as (
 

--- a/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
@@ -1,6 +1,4 @@
 
--- DROP TABLE IF EXISTS default.all_mlab_only_measurements;
-
  CREATE TABLE default.all_mlab_only_measurements
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements',

--- a/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
@@ -32,9 +32,12 @@
 -- ==============================================================================
 
 
- CREATE TABLE IF NOT EXISTS default.all_ping_daily
+-- DROP TABLE IF EXISTS default.all_ping_daily;
+
+ CREATE TABLE default.all_ping_daily
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily',
+    partitioned_by = ARRAY['country']
 )
 AS
 

--- a/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
@@ -32,7 +32,6 @@
 -- ==============================================================================
 
 
--- DROP TABLE IF EXISTS default.all_ping_daily;
 
  CREATE TABLE default.all_ping_daily
 WITH (

--- a/dagster/src/queries/analytics_tables/daily/all_ping_hourly.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_ping_hourly.sql
@@ -30,9 +30,12 @@
 
 
 
-  CREATE TABLE IF NOT EXISTS default.all_ping_hourly
+-- DROP TABLE IF EXISTS default.all_ping_hourly;
+
+  CREATE TABLE default.all_ping_hourly
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly',
+    partitioned_by = ARRAY['country']
 )
 AS (
 

--- a/dagster/src/queries/analytics_tables/daily/all_school_master.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_school_master.sql
@@ -49,10 +49,6 @@ SET SESSION mark_distinct_strategy = 'none';
 SET SESSION query_max_stage_count = 300;
 
 
-
-
--- DROP TABLE IF EXISTS default.all_school_master;
-
 CREATE TABLE default.all_school_master
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_school_master',

--- a/dagster/src/queries/analytics_tables/daily/all_school_master.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_school_master.sql
@@ -51,9 +51,12 @@ SET SESSION query_max_stage_count = 300;
 
 
 
-CREATE TABLE IF NOT EXISTS default.all_school_master
+-- DROP TABLE IF EXISTS default.all_school_master;
+
+CREATE TABLE default.all_school_master
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_school_master'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_school_master',
+    partitioned_by = ARRAY['country']
 )
 AS (
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
@@ -1,6 +1,7 @@
 CREATE TABLE delta_lake.default.all_gmeter_only_measurements_incremental
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements_incremental'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements_incremental',
+    partitioned_by = ARRAY['country']
 )
 AS
 
@@ -84,6 +85,13 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'DailyCheckApp'  -- GigaMeter app measurements only
+    -- Batch cap: bounds this one-time bootstrap run's query cost/memory instead
+    -- of selecting the full unbounded history in one query. The rest of history
+    -- is picked up by repeated update/ runs afterward via the id-based
+    -- watermark (id > MAX(measurement_id) in the target) -- nothing is skipped,
+    -- just spread across more runs.
+    ORDER BY measurement_id
+    LIMIT 40000
 
 )
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_gmeter_only_measurements_incremental.sql
@@ -85,11 +85,6 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'DailyCheckApp'  -- GigaMeter app measurements only
-    -- Batch cap: bounds this one-time bootstrap run's query cost/memory instead
-    -- of selecting the full unbounded history in one query. The rest of history
-    -- is picked up by repeated update/ runs afterward via the id-based
-    -- watermark (id > MAX(measurement_id) in the target) -- nothing is skipped,
-    -- just spread across more runs.
     ORDER BY measurement_id
     LIMIT 40000
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
@@ -97,11 +97,6 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'MLab'  -- MLAB measurements only
-    -- Batch cap: bounds this one-time bootstrap run's query cost/memory instead
-    -- of selecting the full unbounded history in one query. The rest of history
-    -- is picked up by repeated update/ runs afterward via the id-based
-    -- watermark (id > MAX(measurement_id) in the target) -- nothing is skipped,
-    -- just spread across more runs.
     ORDER BY measurement_id
     LIMIT 40000
 )

--- a/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_mlab_only_measurements_incremental.sql
@@ -1,6 +1,7 @@
 CREATE TABLE delta_lake.default.all_mlab_only_measurements_incremental
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements_incremental'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements_incremental',
+    partitioned_by = ARRAY['country']
 )
 AS
 
@@ -96,6 +97,13 @@ measurements_base AS (
         gigameter_production_db.public.measurements
     WHERE
         source = 'MLab'  -- MLAB measurements only
+    -- Batch cap: bounds this one-time bootstrap run's query cost/memory instead
+    -- of selecting the full unbounded history in one query. The rest of history
+    -- is picked up by repeated update/ runs afterward via the id-based
+    -- watermark (id > MAX(measurement_id) in the target) -- nothing is skipped,
+    -- just spread across more runs.
+    ORDER BY measurement_id
+    LIMIT 40000
 )
 
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_daily_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_daily_incremental.sql
@@ -1,7 +1,8 @@
 
 CREATE TABLE delta_lake.default.all_ping_daily_incremental
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily_incremental'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily_incremental',
+    partitioned_by = ARRAY['country']
 )
 AS (
 

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
@@ -1,7 +1,8 @@
 
 CREATE TABLE delta_lake.default.all_ping_hourly_incremental
 WITH (
-    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly_incremental'
+    location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly_incremental',
+    partitioned_by = ARRAY['country']
 )
 AS (
 

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
@@ -92,6 +92,12 @@ measurements_base AS (
           SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_gmeter_only_measurements_incremental
       )
+    -- Batch cap: bounds this run's query cost/memory when catching up a large
+    -- backlog (e.g. after the initial bootstrap, or a missed run). Any rows
+    -- past this batch stay eligible for the id > MAX(measurement_id) watermark
+    -- above and get picked up on the next run -- nothing is skipped.
+    ORDER BY measurement_id
+    LIMIT 40000
 
 )
 

--- a/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_gmeter_only_measurements_incremental.sql
@@ -92,10 +92,6 @@ measurements_base AS (
           SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_gmeter_only_measurements_incremental
       )
-    -- Batch cap: bounds this run's query cost/memory when catching up a large
-    -- backlog (e.g. after the initial bootstrap, or a missed run). Any rows
-    -- past this batch stay eligible for the id > MAX(measurement_id) watermark
-    -- above and get picked up on the next run -- nothing is skipped.
     ORDER BY measurement_id
     LIMIT 40000
 

--- a/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
@@ -103,10 +103,6 @@ measurements_base AS (
           SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_mlab_only_measurements_incremental
       )
-    -- Batch cap: bounds this run's query cost/memory when catching up a large
-    -- backlog (e.g. after the initial bootstrap, or a missed run). Any rows
-    -- past this batch stay eligible for the id > MAX(measurement_id) watermark
-    -- above and get picked up on the next run -- nothing is skipped.
     ORDER BY measurement_id
     LIMIT 40000
 )

--- a/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/update/all_mlab_only_measurements_incremental.sql
@@ -103,6 +103,12 @@ measurements_base AS (
           SELECT COALESCE(MAX(measurement_id), 0)
          FROM delta_lake.default.all_mlab_only_measurements_incremental
       )
+    -- Batch cap: bounds this run's query cost/memory when catching up a large
+    -- backlog (e.g. after the initial bootstrap, or a missed run). Any rows
+    -- past this batch stay eligible for the id > MAX(measurement_id) watermark
+    -- above and get picked up on the next run -- nothing is skipped.
+    ORDER BY measurement_id
+    LIMIT 40000
 )
 
 


### PR DESCRIPTION
## Summary

Ports [unicef/giga-data-analytics#21](https://github.com/unicef/giga-data-analytics/pull/21) into this deployment repo. `giga-data-analytics` is the authoring/validation source of truth for these SQL scripts; this repo is what Dagster actually executes.

No `@asset` or `deps=[]` changes needed — no scripts added/removed, `FROM`/`JOIN` structure unchanged in every file, purely additive `WITH`-clause and `WHERE`-clause edits.

### 1. Country partitioning

Extends #13/#14's precedent (already ported here for `all_gigameter_measurement_data` / `all_gigameter_registered_schools`) to:

- `all_school_master`
- `all_gmeter_only_measurements` (+ `incremental/create/`)
- `all_mlab_only_measurements` (+ `incremental/create/`)
- `all_ping_hourly` (+ `incremental/create/`)
- `all_ping_daily` (+ `incremental/create/`)

`partitioned_by` added as an additional key inside each script's existing `WITH (location = ...)` block (this repo's location-clause convention — Trino only allows one `WITH` clause per statement), not a second `WITH`. Daily-pipeline scripts switch `CREATE TABLE IF NOT EXISTS` → bare `CREATE TABLE` + commented `DROP TABLE IF EXISTS`, same reasoning as `giga-data-analytics`: `IF NOT EXISTS` silently no-ops once the unpartitioned table already exists live.

### 2. Restores the 40k-row incremental batch cap (gmeter/mlab only)

`ORDER BY measurement_id` / `LIMIT 40000` back in the `measurements_base` CTE for `all_gmeter_only_measurements_incremental` and `all_mlab_only_measurements_incremental` (`create/` + `update/`).

This cap was originally **this repo's own** addition — it got wiped out by the `aa5df76` sync commit, which overwrote these files with `giga-data-analytics`'s then-uncapped versions. Restored upstream in `giga-data-analytics`#21 first; this PR round-trips it back here so future syncs don't drop it again.

**Not applied to ping** — `all_ping_hourly_incremental`/`all_ping_daily_incremental` are `GROUP BY` aggregations (school+device+hour/day), not flat per-row tables. No `measurement_id` exists at the output grain, and capping raw `connectivity_ping_checks` rows pre-aggregation risks an undercounted boundary bucket (a different failure mode than gmeter/mlab simply processing fewer new rows per run). Ping keeps its existing MERGE + time-windowed reconciliation as its correctness mechanism, unchanged.

## ⚠️ Manual rebuild required

Same caveat as #13/#14 and the upstream PR — none of these 9 tables are actually partitioned until each is dropped and rebuilt live:

- The 5 daily-pipeline tables have a commented-out `DROP TABLE IF EXISTS` above their `CREATE TABLE` — uncomment and run once.
- The 4 incremental tables need their `create/` script rerun against a dropped table (full historical reload) — schedule deliberately, pause `update/` runs first.
- With the restored 40k cap, `all_gmeter_only_measurements_incremental`/`all_mlab_only_measurements_incremental`'s `create/` run now only bootstraps the first 40k rows; the rest lands via subsequent `update/` runs catching up via the id-based watermark.

## Test plan

- [x] Diff-verified against `giga-data-analytics`#21's merged content — same 11 files, same edits, adapted only for this repo's `location=` convention
- [ ] Rebuild each table per the runbook above once merged, confirm partitioning took effect
- [ ] Confirm the 40k cap behaves as expected on the next `create/` + `update/` cycle for gmeter/mlab

🤖 Generated with [Claude Code](https://claude.com/claude-code)