### PR TITLE
refactor: removing hardcoded filters

### DIFF
--- a/dagster/src/queries/analytics_tables/daily/README.md
+++ b/dagster/src/queries/analytics_tables/daily/README.md
@@ -17,7 +17,7 @@ Scripts are maintained in [`unicef/giga-data-analytics`](https://github.com/unic
 | `all_gigameter_valid_test_checker.sql` | `default.all_gigameter_valid_test_checker` | Per-measurement quality validation (Step 3) | Steps 1 & 2 | Yes — Step 3 incremental in progress |
 | `isp_asn_country_mapping.sql` | `default.isp_asn_country_mapping` | Canonical ISP name/ASN lookup, resolves ASN-truncation variants per country | Steps 1 & 2 | |
 | `all_gigameter_measurement_data.sql` | `default.all_gigameter_measurement_data` | Consolidated validated measurements (Step 4) | Steps 1, 2, & 3, ISP/ASN mapping | Yes — Step 4 incremental in progress |
-| `all_gigameter_measurement_data_daily.sql` | `default.all_gigameter_measurement_data_daily` | Daily aggregation per school+device (weekdays only) — p5/p50/p95 speed metrics, summed data volume, JSON categorical breakdowns, school attributes | `all_gigameter_measurement_data` | |
+| `all_gigameter_measurement_data_daily.sql` | `default.all_gigameter_measurement_data_daily` | Daily aggregation per school+device — p5/p50/p95 speed metrics, summed data volume, JSON categorical breakdowns, school attributes | `all_gigameter_measurement_data` | |
 | `all_gigameter_measurement_data_weekly.sql` | `default.all_gigameter_measurement_data_weekly` | Weekly aggregation per school+device (weekdays only) — identical column structure to daily table | `all_gigameter_measurement_data` | |
 | `all_gigameter_measurement_data_tb_physical.sql` | `default.all_gigameter_measurement_data_tb_physical` | Backwards-compatible measurement data variant | Steps 1 & 2 | |
 | `all_ping_hourly.sql` | `default.all_ping_hourly` | Hourly ping/uptime aggregation per device-school | `gigameter_production_db.connectivity_ping_checks` | |

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_daily.sql
@@ -11,6 +11,5 @@ AS (
         COUNT(*)            AS measurement_count,
         MAX(app_version)    AS latest_app_version
     FROM default.all_gigameter_measurement_data
-    WHERE day_of_week(date) BETWEEN 1 AND 5
     GROUP BY school_id_giga, country, date
 );

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
@@ -76,10 +76,6 @@ FROM
           --  rt_source
         FROM
             default.all_gigameter_measurement_data
-        WHERE
-          measurement_time_window = '8am-4pm(within school hrs)'
-        AND
-          is_weekday = TRUE
     ) AS a
 WHERE
     row_num = 1
@@ -188,10 +184,6 @@ SELECT
     -- select *
 FROM
   default.all_gigameter_measurement_data m
-WHERE
-  measurement_time_window = '8am-4pm(within school hrs)'            -- filter data for those inside measurement window only
-AND
-  is_weekday = TRUE
 group by
     m.country,
     m.iso3_code,

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_school_daily_troubleshooting.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_school_daily_troubleshooting.sql
@@ -5,8 +5,8 @@
 -- ~8.5M row) all_gigameter_measurement_data_incremental table on every dashboard
 -- render — this table lets T0 read from ~2.5M pre-aggregated rows instead, once.
 --
--- One row per school per weekday. Full rebuild: drop and recreate (small table —
--- schools x working days, same shape as all_gigameter_measurement_data_daily).
+-- One row per school per day. Full rebuild: drop and recreate (small table —
+-- schools x days, same shape as all_gigameter_measurement_data_daily).
 --
 -- Deliberately separate from the in-progress device-grain all_gigameter_measurement_
 -- data_daily/_weekly rework (still "Testing" status, direction not yet locked) —
@@ -88,6 +88,5 @@ AS (
         MAX(detected_location_distance) AS max_location_distance_m
 
     FROM default.all_gigameter_measurement_data_incremental
-    WHERE day_of_week(date) BETWEEN 1 AND 5
     GROUP BY school_id_giga, country, date
 );


### PR DESCRIPTION
## Summary

Mirrors unicef/giga-data-analytics#22 (merged). Removes the hardcoded `is_weekday` / `measurement_time_window` / `day_of_week(...)` row filters from three pipeline scripts so they emit complete, unfiltered data:

- `all_gigameter_registered_schools.sql` — removed `WHERE measurement_time_window = '8am-4pm(within school hrs)' AND is_weekday = TRUE` from both the `last_measurement_date` and `measurement_data` CTEs.
- `all_gigameter_school_daily_troubleshooting.sql` — removed `WHERE day_of_week(date) BETWEEN 1 AND 5`. Updated the stale "one row per school per weekday" header comment.
- `all_gigameter_measurement_data_daily.sql` — removed `WHERE day_of_week(date) BETWEEN 1 AND 5`. Updated the stale "(weekdays only)" note in `daily/README.md`.

## Why

Weekday/school-hours restriction is a presentation concern, not a pipeline concern — these tables should hold the complete dataset. Filtering belongs at the dashboard/dataset-query level in Superset, closer to where it's actually consumed. This also prepares for using Superset's native/cached dashboard-level filters instead of baking a fixed subset into every table rebuild. A companion Superset session is already applying dashboard-level native filters on dashboard 21 to compensate.

## Deliberately out of scope

- **`all_gigameter_school_consistency_history.sql`** also contains these conditions, but they're core scoring logic (numerator/denominator of `consistency_score`/`coverage_rate_pct`), not a display-layer row filter — left untouched, same as the data-analytics PR.
- **`all_gigameter_measurement_data_weekly.sql`** intentionally keeps its filter. Its rows are already aggregated to week grain (COUNT, percentile speeds, etc.), so a weekday-only slice can't be reconstructed downstream once collapsed — unlike the daily table, which retains a per-row `date`.
- **Incremental scripts** (`incremental/create/` and `incremental/update/` for `all_gigameter_measurement_data`, `all_gmeter_only_measurements`, `all_mlab_only_measurements`) were checked and confirmed to only *derive* `is_weekday`/`measurement_time_window` as output columns (`CASE`/`CAST`) — they don't filter rows on them, so nothing needed changing there.

## Breaking change / follow-up

Same as the data-analytics PR: the three affected tables now return weekend/off-hours rows they previously excluded. The Superset T0 troubleshooting dashboard (dashboard 21, dataset 110) and any other charts on these tables need the equivalent filter applied at the dashboard level — being handled in a separate Superset session using native dashboard filters on dashboard 21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)