### PR TITLE
fix: prevent memory limit being exceeded on create

### DIFF
--- a/dagster/src/queries/analytics_tables/incremental/README.md
+++ b/dagster/src/queries/analytics_tables/incremental/README.md
@@ -39,6 +39,13 @@ bucket if a ping arrives late. It uses `MERGE INTO` instead of `INSERT INTO` —
 block at the top of `update/all_ping_hourly_incremental.sql` for the full reasoning (4-hour grace
 period + `connectivity_ids`-based reconciliation).
 
+`create/all_ping_hourly_incremental.sql` (the one-time bootstrap) is also non-standard: unlike
+every other `create/` script here, which is a single unbounded statement, it's a sequence of
+one `CREATE TABLE` plus several `INSERT`s, each bounded to a disjoint, hour-aligned local-time
+window — a fix for a production `EXCEEDED_LOCAL_MEMORY_LIMIT` failure when the full unbounded
+history was aggregated in one `GROUP BY`. See the header comment in that file for the chunk
+sizing and stop-point reasoning.
+
 ---
 
 ## Scripts

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
@@ -1,4 +1,60 @@
+-- =============================================================================
+-- BOOTSTRAP: chunked historical backfill
+--
+-- This table's GROUP BY (school+device+hour, with ARRAY_AGG(DISTINCT
+-- connectivity_id) per bucket) cannot aggregate the full history of
+-- connectivity_ping_checks in one query -- it hits Trino's per-node memory
+-- limit (HashAggregationOperator exceeded 4GB against ~29M raw ping rows,
+-- 2026-08-19). A raw-row LIMIT isn't safe here either: this table is built
+-- once via CREATE TABLE and never revisited by a create/ run again (Dagster
+-- switches to update/'s MERGE on every run after the table exists), and
+-- create/ has no MERGE to self-correct a bucket whose raw pings got split
+-- across an arbitrary row-count cutoff.
+--
+-- Instead this file is a sequence of statements -- one CREATE TABLE for the
+-- earliest chunk, then INSERT INTO for each later chunk -- each bounded to a
+-- local-time window using the same two-tier filter as update/:
+--   - ping_base: a wide raw-UTC buffer (+/- 72h) around the chunk -- a
+--     performance/safety margin only, not the correctness boundary.
+--   - ping_enriched: the precise local-to-local filter on local_ts, applied
+--     after timezone conversion.
+-- Because local_date_hour = date_trunc('hour', local_ts) and every chunk
+-- boundary below is an hour-aligned (midnight) timestamp literal, no
+-- school+device+hour bucket can ever be split across two chunks -- every raw
+-- ping's local_ts falls in exactly one chunk's [start, end) range by
+-- construction. No dedup/anti-join is needed between chunks for that reason.
+--
+-- Chunk boundaries were sized from the actual row distribution in production
+-- (SELECT date_trunc('day', timestamp), COUNT(*) ... GROUP BY 1, checked
+-- 2026-08-19): volume is extremely back-loaded -- ~29.3M of ~29.4M total
+-- rows fall in 2026 Q1-Q3 alone (ping monitoring scaled up sharply this
+-- year), so a uniform quarterly or monthly chunk width badly under- or
+-- over-shoots depending on the period. Chunk 1 covers all sparse history
+-- through end of 2025 (~144K rows); chunks 2-10 target ~3.3-3.5M rows each
+-- across the dense 2026 period -- comfortably under the ~4.37M rows that
+-- daily/all_ping_hourly.sql's proven-working 90-day production window
+-- processes today.
+--
+-- Chunk 1's floor (2018-01-01) also deliberately excludes a small number of
+-- provably-implausible raw timestamps found in connectivity_ping_checks
+-- (observed MIN was 1980-01-01, MAX was year 8663 -- ~7.5K rows total,
+-- <0.03% of the table, predating this program's existence or postdating
+-- "now" by millennia; a known data-quality issue already called out in
+-- ../../incremental/README.md for other scripts, previously unfiltered here
+-- because create/ had no time bound at all).
+--
+-- Stop point: chunk 10 ends 2026-08-15, a few days before "now" (2026-08-19)
+-- rather than chunking to the live edge. The already-scheduled hourly
+-- update/ MERGE job (cron 15 * * * *) picks up everything from there
+-- forward on its own watermark (MAX(local_date_hour) in this table) -- its
+-- existing 72h/48h buffers comfortably span that gap. Nothing past this
+-- script's boundaries is lost, just deferred to the next few scheduled
+-- update/ runs, the same deferral pattern the 4-hour settlement grace period
+-- already uses.
+-- =============================================================================
 
+
+-- CHUNK 1 of 10: 2018-01-01 00:00:00 -> 2025-12-31 00:00:00  (bootstrap CREATE)
 CREATE TABLE delta_lake.default.all_ping_hourly_incremental
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_hourly_incremental',
@@ -6,15 +62,6 @@ WITH (
 )
 AS (
 
--- =============================================================================
--- CTE: school_lookup
--- Purpose: Creates a reusable lookup for school metadata with pre-computed timezone
---
--- Timezone Fallback Chain:
---   1. Try timezone by ISO3 code (tz.timezone)
---   2. Try timezone by country name (tz_name.timezone)
---   3. Default to 'UTC'
--- =============================================================================
 WITH school_lookup AS (
 
     SELECT
@@ -42,17 +89,6 @@ WITH school_lookup AS (
     WHERE
         school.deleted IS NULL
 )
-
-
--- =============================================================================
--- CTE: ping_base
--- Purpose: Extract raw ping connectivity checks
---
--- NO TIME FILTER: unlike the 90-day rolling window in the daily drop-and-recreate
--- version (all_ping_hourly.sql), this initial build reads all available raw ping
--- history so the incremental table starts with complete history, not a 90-day
--- slice of it. The update/ script re-filters going forward from there.
--- =============================================================================
 , ping_base AS (
 
     SELECT
@@ -68,18 +104,10 @@ WITH school_lookup AS (
         cpc.latency
     FROM
       gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2018-01-01 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2025-12-31 00:00:00' + INTERVAL '72' HOUR
 )
-
-
--- =============================================================================
--- CTE: ping_enriched
--- Purpose: Join raw pings to school metadata and compute the LOCAL timestamp
---
--- Computing local_ts here (rather than filtering ping_base on the raw UTC
--- cpc.timestamp first) means any future watermark/window filter in the update/
--- script can compare local-to-local against local_date_hour with no timezone
--- skew to account for.
--- =============================================================================
 , ping_enriched as (
 
 SELECT
@@ -114,18 +142,11 @@ LEFT JOIN
 ON
   pb.school_id_giga = sl.school_id_giga
 
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2018-01-01 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2025-12-31 00:00:00'
+
  )
-
-
--- =============================================================================
--- CTE: ping_aggr
--- Purpose: Aggregate ping data by school-device-hour
---
--- connectivity_ids: the raw ping ids that fed into each bucket. Not part of the
--- daily version's schema — kept here so the update/ script can detect pings
--- that arrive late (after their bucket was already inserted) by comparing this
--- array against what's already stored, and correct that bucket via MERGE.
--- =============================================================================
  , ping_aggr AS (
 
 
@@ -179,10 +200,6 @@ ON
 )
 
 
--- =============================================================================
--- FINAL SELECT
--- Purpose: Output ping-only aggregated data with first ping validation
--- =============================================================================
 SELECT
   DISTINCT
     CAST(p.local_created_date AS DATE) AS local_created_date,
@@ -225,3 +242,1705 @@ FROM
   ping_aggr p
 
 )
+;
+
+-- CHUNK 2 of 10: 2025-12-31 00:00:00 -> 2026-01-30 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2025-12-31 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-01-30 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2025-12-31 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-01-30 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 3 of 10: 2026-01-30 00:00:00 -> 2026-02-14 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-01-30 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-02-14 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-01-30 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-02-14 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 4 of 10: 2026-02-14 00:00:00 -> 2026-03-03 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-02-14 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-03-03 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-02-14 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-03-03 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 5 of 10: 2026-03-03 00:00:00 -> 2026-03-19 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-03-03 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-03-19 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-03-03 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-03-19 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 6 of 10: 2026-03-19 00:00:00 -> 2026-04-10 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-03-19 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-04-10 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-03-19 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-04-10 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 7 of 10: 2026-04-10 00:00:00 -> 2026-04-28 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-04-10 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-04-28 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-04-10 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-04-28 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 8 of 10: 2026-04-28 00:00:00 -> 2026-05-15 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-04-28 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-05-15 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-04-28 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-05-15 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 9 of 10: 2026-05-15 00:00:00 -> 2026-06-27 00:00:00
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-05-15 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-06-27 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-05-15 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-06-27 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;
+
+-- CHUNK 10 of 10: 2026-06-27 00:00:00 -> 2026-08-15 00:00:00  (stop point -- update/ takes the tail from here)
+INSERT INTO delta_lake.default.all_ping_hourly_incremental
+(
+    local_created_date, local_date_hour, local_date_minus_1hr, local_hour,
+    device_id, school_id_govt, school_id_giga, school_name, country, admin1, admin2,
+    expected_pings_per_hour, missing_pings, ping_records, is_connected_true,
+    is_school_hours, latency_ping, uptime, availability, connectivity_ids
+)
+WITH school_lookup AS (
+
+    SELECT
+        school.giga_id_school AS school_id_giga,
+        school.external_id AS school_id_govt,
+        school.name AS school_name,
+        country.name AS country,
+        country.code AS iso2_code,
+        UPPER(TRIM(country.iso3_format)) AS iso3_code,
+        COALESCE(tz.timezone, tz_name.timezone, 'UTC') AS timezone,
+
+        school.admin_1_name AS admin_1,
+        school.admin_2_name AS admin_2,
+        school.admin_3_name AS admin_3,
+        school.admin_4_name AS admin_4
+    FROM
+        gigameter_production_db.public.school
+    LEFT JOIN
+        gigameter_production_db.public.country
+        ON country.id = school.country_id
+    LEFT JOIN default.country_timezones tz
+        ON country.iso3_format = tz.iso3
+    LEFT JOIN default.country_timezones tz_name
+        ON LOWER(country.name) = LOWER(tz_name.country)
+    WHERE
+        school.deleted IS NULL
+)
+, ping_base AS (
+
+    SELECT
+      DISTINCT
+        cpc.id AS connectivity_id,
+        cpc.timestamp,
+        cpc.is_connected,
+        cpc.error_message,
+        cpc.giga_id_school AS school_id_giga,
+        cpc.app_local_uuid,
+        cpc.browser_id AS device_id,
+        cpc.created_at AS connectivity_created_at,
+        cpc.latency
+    FROM
+      gigameter_production_db.public.connectivity_ping_checks cpc
+    WHERE
+      cpc.timestamp >= TIMESTAMP '2026-06-27 00:00:00' - INTERVAL '72' HOUR
+      AND cpc.timestamp <  TIMESTAMP '2026-08-15 00:00:00' + INTERVAL '72' HOUR
+)
+, ping_enriched as (
+
+SELECT
+
+        CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) AS local_ts,
+    ---- PING DATA FIELDS
+        pb.connectivity_id,
+        pb.is_connected,
+        pb.error_message,
+        pb.app_local_uuid,
+        pb.device_id,
+        pb.connectivity_created_at,
+        pb.latency,
+    ---- SCHOOL DATA FIELDS
+        sl.school_id_giga,
+        sl.school_id_govt,
+        sl.school_name,
+        sl.country,
+        sl.iso2_code,
+        sl.iso3_code,
+        sl.timezone,
+
+        sl.admin_1,
+        sl.admin_2,
+        sl.admin_3,
+        sl.admin_4
+
+FROM
+  ping_base pb
+LEFT JOIN
+  school_lookup sl
+ON
+  pb.school_id_giga = sl.school_id_giga
+
+WHERE
+  CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) >= TIMESTAMP '2026-06-27 00:00:00'
+  AND CAST(at_timezone(pb.timestamp, sl.timezone) AS TIMESTAMP) <  TIMESTAMP '2026-08-15 00:00:00'
+
+ )
+ , ping_aggr AS (
+
+
+    SELECT
+        CAST(local_ts AS DATE) AS local_created_date,
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP) AS local_date_hour,
+        EXTRACT(HOUR FROM local_ts) AS local_hour,
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id,
+
+        COUNT(*) AS ping_records,
+        4 - COALESCE(COUNT(*), 0) AS missing_pings,
+        AVG(latency) AS avg_latency,
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END) as is_connected_true,
+
+        -- Uptime: ratio of connected pings to total pings
+        SUM(CASE WHEN is_connected = TRUE THEN 1 ELSE 0 END)
+            / CAST(COUNT(*) AS DECIMAL(10,2)) AS uptime,
+
+        -- AVAILABILITY: ratio of signals recieved vs expected
+        1 - ( (4 - COALESCE(COUNT(*), 0)) / cast(4 AS DECIMAL(10,2)) ) as availability,
+
+        -- Raw ping ids in this bucket, sorted for stable equality comparison in the
+        -- update/ script's MERGE (ARRAY_AGG order is not otherwise guaranteed)
+        ARRAY_SORT(ARRAY_AGG(DISTINCT connectivity_id)) AS connectivity_ids
+
+    FROM
+      ping_enriched
+
+    GROUP BY
+        CAST(local_ts AS DATE),
+        CAST(date_trunc('hour', local_ts) AS TIMESTAMP),
+        EXTRACT(HOUR FROM local_ts),
+        country,
+        school_id_giga,
+        school_id_govt,
+        school_name,
+        admin_1,
+        admin_2,
+        admin_3,
+        admin_4,
+        device_id
+
+)
+
+
+SELECT
+  DISTINCT
+    CAST(p.local_created_date AS DATE) AS local_created_date,
+    CAST(p.local_date_hour AS TIMESTAMP) AS local_date_hour,
+
+    -- Hour offset for timezone alignment
+    CAST(date_add('hour', -1, p.local_date_hour) AS TIMESTAMP) AS local_date_minus_1hr,
+    CAST(p.local_hour AS BIGINT) AS local_hour,
+
+    -- Device and school identifiers
+    CAST(p.device_id AS VARCHAR) AS device_id,
+    CAST(p.school_id_govt AS VARCHAR) AS school_id_govt,
+    CAST(p.school_id_giga AS VARCHAR) AS school_id_giga,
+    CAST(p.school_name AS VARCHAR) AS school_name,
+    CAST(p.country AS VARCHAR) AS country,
+    CAST(p.admin_1 AS VARCHAR) AS admin1,
+    CAST(p.admin_2 AS VARCHAR) AS admin2,
+
+    -- Ping completeness metrics (4 expected: 1 ping every 15 minutes)
+    CAST(4 AS BIGINT) AS expected_pings_per_hour,
+    CAST(p.missing_pings AS BIGINT) AS missing_pings,
+
+    -- Ping metrics
+    CAST(p.ping_records AS BIGINT) AS ping_records,
+    CAST(p.is_connected_true AS BIGINT) AS is_connected_true,
+
+    -- School hours indicator: TRUE for hours 8-20 (8am-8pm)
+    CAST(p.local_hour BETWEEN 8 AND 20 AS BOOLEAN) AS is_school_hours,
+
+    CAST(p.avg_latency AS DOUBLE) AS latency_ping,
+    -- Uptime represents what proportion of ping signals received were connected
+    CAST(p.uptime AS DOUBLE) AS uptime,
+    -- availability gives a % of how many times device was available for ping
+    CAST(p.availability AS DOUBLE) AS availability,
+
+    -- Reconciliation tracking column - see ping_aggr comment above
+    p.connectivity_ids
+
+FROM
+  ping_aggr p
+
+;

--- a/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
+++ b/dagster/src/queries/analytics_tables/incremental/create/all_ping_hourly_incremental.sql
@@ -1,56 +1,20 @@
 -- =============================================================================
 -- BOOTSTRAP: chunked historical backfill
 --
--- This table's GROUP BY (school+device+hour, with ARRAY_AGG(DISTINCT
--- connectivity_id) per bucket) cannot aggregate the full history of
--- connectivity_ping_checks in one query -- it hits Trino's per-node memory
--- limit (HashAggregationOperator exceeded 4GB against ~29M raw ping rows,
--- 2026-08-19). A raw-row LIMIT isn't safe here either: this table is built
--- once via CREATE TABLE and never revisited by a create/ run again (Dagster
--- switches to update/'s MERGE on every run after the table exists), and
--- create/ has no MERGE to self-correct a bucket whose raw pings got split
--- across an arbitrary row-count cutoff.
+-- A full-history GROUP BY in one query exceeds Trino's per-node memory limit
+-- (~29M raw rows, 2026-08-19). A raw-row LIMIT isn't safe: create/ runs once
+-- only (Dagster switches to update/'s MERGE once the table exists), and has
+-- no MERGE to fix a bucket split by an arbitrary cutoff.
 --
--- Instead this file is a sequence of statements -- one CREATE TABLE for the
--- earliest chunk, then INSERT INTO for each later chunk -- each bounded to a
--- local-time window using the same two-tier filter as update/:
---   - ping_base: a wide raw-UTC buffer (+/- 72h) around the chunk -- a
---     performance/safety margin only, not the correctness boundary.
---   - ping_enriched: the precise local-to-local filter on local_ts, applied
---     after timezone conversion.
--- Because local_date_hour = date_trunc('hour', local_ts) and every chunk
--- boundary below is an hour-aligned (midnight) timestamp literal, no
--- school+device+hour bucket can ever be split across two chunks -- every raw
--- ping's local_ts falls in exactly one chunk's [start, end) range by
--- construction. No dedup/anti-join is needed between chunks for that reason.
---
--- Chunk boundaries were sized from the actual row distribution in production
--- (SELECT date_trunc('day', timestamp), COUNT(*) ... GROUP BY 1, checked
--- 2026-08-19): volume is extremely back-loaded -- ~29.3M of ~29.4M total
--- rows fall in 2026 Q1-Q3 alone (ping monitoring scaled up sharply this
--- year), so a uniform quarterly or monthly chunk width badly under- or
--- over-shoots depending on the period. Chunk 1 covers all sparse history
--- through end of 2025 (~144K rows); chunks 2-10 target ~3.3-3.5M rows each
--- across the dense 2026 period -- comfortably under the ~4.37M rows that
--- daily/all_ping_hourly.sql's proven-working 90-day production window
--- processes today.
---
--- Chunk 1's floor (2018-01-01) also deliberately excludes a small number of
--- provably-implausible raw timestamps found in connectivity_ping_checks
--- (observed MIN was 1980-01-01, MAX was year 8663 -- ~7.5K rows total,
--- <0.03% of the table, predating this program's existence or postdating
--- "now" by millennia; a known data-quality issue already called out in
--- ../../incremental/README.md for other scripts, previously unfiltered here
--- because create/ had no time bound at all).
---
--- Stop point: chunk 10 ends 2026-08-15, a few days before "now" (2026-08-19)
--- rather than chunking to the live edge. The already-scheduled hourly
--- update/ MERGE job (cron 15 * * * *) picks up everything from there
--- forward on its own watermark (MAX(local_date_hour) in this table) -- its
--- existing 72h/48h buffers comfortably span that gap. Nothing past this
--- script's boundaries is lost, just deferred to the next few scheduled
--- update/ runs, the same deferral pattern the 4-hour settlement grace period
--- already uses.
+-- Fix: one CREATE + nine INSERTs, each bounded to an hour-aligned local-time
+-- window using update/'s two-tier filter (wide raw-UTC buffer in ping_base,
+-- precise local-to-local boundary in ping_enriched) -- since
+-- local_date_hour = date_trunc('hour', local_ts), no bucket can be split
+-- across chunks. Boundaries sized from actual 2026-08-19 row distribution
+-- (volume is back-loaded into 2026, so widths aren't uniform). Chunk 1's
+-- floor (2018-01-01) excludes ~7.5K rows with implausible timestamps (1980,
+-- year 8663). Chunk 10 stops 2026-08-15; update/'s hourly MERGE closes the
+-- rest on its own watermark.
 -- =============================================================================
 
 


### PR DESCRIPTION
## Summary
Ports [unicef/giga-data-analytics#23](https://github.com/unicef/giga-data-analytics/pull/23) into this deployment repo. No `@asset` or `deps=[]` changes needed — same script, no new files, `_read_statements`/`_execute_statements` already run a file's statements in sequence.

- `create/all_ping_hourly_incremental.sql` aggregated the full unbounded history of `connectivity_ping_checks` in one `GROUP BY`, hitting Trino's per-node memory limit
- Replaced the single `CREATE TABLE ... AS (...)` with one `CREATE` + nine `INSERT`s, each bounded to a disjoint, hour-aligned local-time window using the same two-tier raw-UTC-buffer + precise-local-filter pattern already proven in `update/all_ping_hourly_incremental.sql`
- Preserves this repo's `{AZURE_BLOB_CONNECTION_URI}` location placeholder (only the `CREATE` statement has a `location=` clause; the `INSERT`s don't need one)
- A raw-row `LIMIT` was ruled out: `create/` only ever runs once (`_run_incremental` switches permanently to `update/`'s `MERGE` once the table exists), and `create/` has no `MERGE` to self-correct a bucket split by an arbitrary row-count cutoff
- Adds a short note to `incremental/README.md` documenting the chunked-bootstrap design

## Test plan
- [x] Validated in giga-data-analytics#23 (chunking correctness + memory-safety of the largest real chunk)
- [ ] Merge alongside/after giga-data-analytics#23
- [ ] Confirm the real bootstrap run completes without `EXCEEDED_LOCAL_MEMORY_LIMIT` in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)