### PR TITLE
refactor: restore DROP TABLE statements to all daily create scripts

### DIFF
--- a/dagster/src/queries/analytics_tables/daily/all_gigamaps_realtimeconnectivity.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigamaps_realtimeconnectivity.sql
@@ -29,6 +29,8 @@
 -- ==============================================================================
 
 
+ DROP TABLE IF EXISTS default.all_gigamaps_realtimeconnectivity;
+
  CREATE TABLE IF NOT EXISTS  default.all_gigamaps_realtimeconnectivity
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigamaps_realtimeconnectivity'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_appversion_funnel.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_appversion_funnel.sql
@@ -30,6 +30,8 @@
 --
 -- ==============================================================================
 
+  DROP TABLE IF EXISTS default.all_gigameter_appversion_funnel;
+
   CREATE TABLE IF NOT EXISTS default.all_gigameter_appversion_funnel
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_appversion_funnel'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_funnelsummary.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_funnelsummary.sql
@@ -38,6 +38,8 @@
 -- ==============================================================================
 
 
+  DROP TABLE IF EXISTS default.all_gigameter_funnelsummary;
+
   CREATE TABLE IF NOT EXISTS  default.all_gigameter_funnelsummary
   WITH (
       location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_funnelsummary'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_inc_ping_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_inc_ping_daily.sql
@@ -29,6 +29,8 @@
 -- ==============================================================================
 
 
+DROP TABLE IF EXISTS default.all_gigameter_inc_ping_daily;
+
 CREATE TABLE IF NOT EXISTS default.all_gigameter_inc_ping_daily
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_inc_ping_daily'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data.sql
@@ -1,5 +1,7 @@
 
 
+ DROP TABLE IF EXISTS default.all_gigameter_measurement_data;
+
  CREATE TABLE IF NOT EXISTS default.all_gigameter_measurement_data
  WITH (
      location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data',

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_daily.sql
@@ -1,4 +1,6 @@
 
+DROP TABLE IF EXISTS default.all_gigameter_measurement_data_daily;
+
 CREATE TABLE default.all_gigameter_measurement_data_daily
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data_daily'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_tb_physical.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_tb_physical.sql
@@ -31,6 +31,8 @@
 -- ==============================================================================
 
 
+DROP TABLE IF EXISTS default.all_gigameter_measurement_data_tb_physical;
+
 CREATE TABLE IF NOT EXISTS default.all_gigameter_measurement_data_tb_physical
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data_tb_physical'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_weekly.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_measurement_data_weekly.sql
@@ -1,4 +1,6 @@
 
+DROP TABLE IF EXISTS default.all_gigameter_measurement_data_weekly;
+
 CREATE TABLE default.all_gigameter_measurement_data_weekly
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_measurement_data_weekly'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_devices.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_devices.sql
@@ -35,6 +35,8 @@
 -- Last Updated:    2025-10-31 / Luke Stringer
 -- ==============================================================================
 
+ DROP TABLE IF EXISTS default.all_gigameter_registered_devices;
+
  CREATE TABLE IF NOT EXISTS default.all_gigameter_registered_devices
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_registered_devices'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_schools.sql
@@ -45,7 +45,7 @@
 -- Last Updated:    2026-07-30 / Luke Stringer
 -- ==============================================================================
 
--- DROP TABLE IF EXISTS default.all_gigameter_registered_schools;
+DROP TABLE IF EXISTS default.all_gigameter_registered_schools;
 
 CREATE TABLE default.all_gigameter_registered_schools
 WITH (

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_tb_physical.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_registered_tb_physical.sql
@@ -45,6 +45,8 @@
 -- ==============================================================================
 
 
+DROP TABLE IF EXISTS default.all_gigameter_registered_tb_physical;
+
 CREATE TABLE IF NOT EXISTS default.all_gigameter_registered_tb_physical
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_registered_tb_physical'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_school_consistency_history.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_school_consistency_history.sql
@@ -36,6 +36,8 @@
 
 
 
+ DROP TABLE IF EXISTS default.all_gigameter_school_consistency_history;
+
  CREATE TABLE default.all_gigameter_school_consistency_history
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_school_consistency_history'

--- a/dagster/src/queries/analytics_tables/daily/all_gigameter_valid_test_checker.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gigameter_valid_test_checker.sql
@@ -2,6 +2,8 @@
 
 
 
+DROP TABLE IF EXISTS default.all_gigameter_valid_test_checker;
+
 CREATE TABLE IF NOT EXISTS default.all_gigameter_valid_test_checker
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gigameter_valid_test_checker'

--- a/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_gmeter_only_measurements.sql
@@ -1,6 +1,8 @@
 
 
 
+  DROP TABLE IF EXISTS default.all_gmeter_only_measurements;
+
   CREATE TABLE default.all_gmeter_only_measurements
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_gmeter_only_measurements',

--- a/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_mlab_only_measurements.sql
@@ -1,4 +1,6 @@
 
+ DROP TABLE IF EXISTS default.all_mlab_only_measurements;
+
  CREATE TABLE default.all_mlab_only_measurements
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_mlab_only_measurements',

--- a/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_ping_daily.sql
@@ -33,6 +33,8 @@
 
 
 
+ DROP TABLE IF EXISTS default.all_ping_daily;
+
  CREATE TABLE default.all_ping_daily
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_ping_daily',

--- a/dagster/src/queries/analytics_tables/daily/all_ping_hourly.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_ping_hourly.sql
@@ -30,7 +30,7 @@
 
 
 
--- DROP TABLE IF EXISTS default.all_ping_hourly;
+DROP TABLE IF EXISTS default.all_ping_hourly;
 
   CREATE TABLE default.all_ping_hourly
 WITH (

--- a/dagster/src/queries/analytics_tables/daily/all_school_master.sql
+++ b/dagster/src/queries/analytics_tables/daily/all_school_master.sql
@@ -49,6 +49,8 @@ SET SESSION mark_distinct_strategy = 'none';
 SET SESSION query_max_stage_count = 300;
 
 
+DROP TABLE IF EXISTS default.all_school_master;
+
 CREATE TABLE default.all_school_master
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/all_school_master',

--- a/dagster/src/queries/analytics_tables/daily/bra_benchmarkstatus_wow.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_benchmarkstatus_wow.sql
@@ -33,6 +33,8 @@
 -- ==============================================================================
 
 
+ DROP TABLE IF EXISTS default.bra_benchmarkstatus_wow;
+
  CREATE TABLE IF NOT EXISTS default.bra_benchmarkstatus_wow
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_benchmarkstatus_wow'

--- a/dagster/src/queries/analytics_tables/daily/bra_nicbr_daily.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_nicbr_daily.sql
@@ -1,6 +1,8 @@
 
 
 
+ DROP TABLE IF EXISTS default.bra_nicbr_daily;
+
  CREATE TABLE IF NOT EXISTS default.bra_nicbr_daily
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_daily'

--- a/dagster/src/queries/analytics_tables/daily/bra_nicbr_registered_schools.sql
+++ b/dagster/src/queries/analytics_tables/daily/bra_nicbr_registered_schools.sql
@@ -29,6 +29,8 @@
 -- Last Updated:    2025-10-31 / Luke Stringer
 -- ==============================================================================
 
+ DROP TABLE IF EXISTS default.bra_nicbr_registered_schools;
+
  CREATE TABLE IF NOT EXISTS default.bra_nicbr_registered_schools
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/bra_nicbr_registered_schools'

--- a/dagster/src/queries/analytics_tables/daily/country_versions.sql
+++ b/dagster/src/queries/analytics_tables/daily/country_versions.sql
@@ -32,6 +32,8 @@ SET SESSION mark_distinct_strategy = 'none';
 SET SESSION query_max_stage_count = 400;
 
 
+DROP TABLE IF EXISTS default.country_versions;
+
 CREATE TABLE IF NOT EXISTS default.country_versions
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/country_versions'

--- a/dagster/src/queries/analytics_tables/daily/isp_asn_country_mapping.sql
+++ b/dagster/src/queries/analytics_tables/daily/isp_asn_country_mapping.sql
@@ -42,6 +42,8 @@
 -- Last Updated:    2026-07-30 / Luke Stringer
 -- ==============================================================================
 
+DROP TABLE IF EXISTS default.isp_asn_country_mapping;
+
 CREATE TABLE default.isp_asn_country_mapping
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/isp_asn_country_mapping'

--- a/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_measurements.sql
+++ b/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_measurements.sql
@@ -32,6 +32,8 @@
 -- ==============================================================================
 
 
+DROP TABLE IF EXISTS default.mng_gigameter_qos_measurements;
+
 CREATE TABLE IF NOT EXISTS default.mng_gigameter_qos_measurements
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/mng_gigameter_qos_measurements'

--- a/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_registered.sql
+++ b/dagster/src/queries/analytics_tables/daily/mng_gigameter_qos_registered.sql
@@ -52,6 +52,8 @@
 
 
 
+DROP TABLE IF EXISTS default.mng_gigameter_qos_registered;
+
 CREATE TABLE IF NOT EXISTS default.mng_gigameter_qos_registered
 WITH (
     location = '{AZURE_BLOB_CONNECTION_URI}/warehouse/mng_gigameter_qos_registered'


### PR DESCRIPTION
## Summary
- A previous port from `giga-data-analytics` (`remove-hardcoded-filters`, #493) carried over the deletion of `DROP TABLE` lines from several daily create scripts. DROP statements were only ever meant to be removed from **incremental model scripts** (which append via `INSERT INTO ..._test` and never had one) — not from daily create scripts, which rely on a drop-and-recreate pattern to rebuild cleanly on each run.
- Restores/adds an active `DROP TABLE IF EXISTS default.<table>;` immediately before the `CREATE TABLE` statement in all 25 scripts under `dagster/src/queries/analytics_tables/daily/` — uncommenting it where it existed (`all_gigameter_registered_schools`, `all_ping_hourly`) and inserting it fresh where it was missing entirely (the remaining 23 files, including `all_ping_daily` and `all_school_master` which this repo's port had fully deleted rather than just commented).
- `dagster/src/queries/analytics_tables/incremental/` scripts are untouched — no incremental script has ever had a DROP statement.

## Test plan
- [ ] `grep -rL "DROP TABLE IF EXISTS" dagster/src/queries/analytics_tables/daily/*.sql` returns no files
- [ ] Spot-check a few edited files for correct table name / placement
- [ ] Confirm no `incremental/` files changed (`git diff --stat`)

Companion PR in `unicef/giga-data-analytics`: https://github.com/unicef/giga-data-analytics/pull/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YYdtA49feh6gmWrLRHchT